### PR TITLE
Skip unnecessary authorization views

### DIFF
--- a/TemplateApplication.xcodeproj/project.pbxproj
+++ b/TemplateApplication.xcodeproj/project.pbxproj
@@ -9,7 +9,6 @@
 /* Begin PBXBuildFile section */
 		27FA29902A388E9B009CAC45 /* ModalView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 27FA298F2A388E9B009CAC45 /* ModalView.swift */; };
 		2F1B52CE2A4F5CCE003AE151 /* MockUploadTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F1B52CD2A4F5CCE003AE151 /* MockUploadTests.swift */; };
-		2F3D4ABC2A4E7C290068FB2F /* SpeziScheduler in Frameworks */ = {isa = PBXBuildFile; productRef = 2F3D4ABB2A4E7C290068FB2F /* SpeziScheduler */; };
 		2F49B7762980407C00BCB272 /* Spezi in Frameworks */ = {isa = PBXBuildFile; productRef = 2F49B7752980407B00BCB272 /* Spezi */; };
 		2F4E237E2989A2FE0013F3D9 /* OnboardingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F4E237D2989A2FE0013F3D9 /* OnboardingTests.swift */; };
 		2F4E23832989D51F0013F3D9 /* TemplateAppTestingSetup.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F4E23822989D51F0013F3D9 /* TemplateAppTestingSetup.swift */; };
@@ -18,7 +17,6 @@
 		2F5E32BD297E05EA003432F8 /* TemplateAppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F5E32BC297E05EA003432F8 /* TemplateAppDelegate.swift */; };
 		2F6025CB29BBE70F0045459E /* GoogleService-Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = 2F6025CA29BBE70F0045459E /* GoogleService-Info.plist */; };
 		2F65B44E2A3B8B0600A36932 /* NotificationPermissions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F65B44D2A3B8B0600A36932 /* NotificationPermissions.swift */; };
-		2FBD738C2A3BD150004228E7 /* SpeziScheduler in Frameworks */ = {isa = PBXBuildFile; productRef = 2FBD738B2A3BD150004228E7 /* SpeziScheduler */; };
 		2FC3439029EE6346002D773C /* SocialSupportQuestionnaire.json in Resources */ = {isa = PBXBuildFile; fileRef = 2FE5DC5529EDD811004B9AB4 /* SocialSupportQuestionnaire.json */; };
 		2FC3439129EE6349002D773C /* AppIcon.png in Resources */ = {isa = PBXBuildFile; fileRef = 2FE5DC2A29EDD78D004B9AB4 /* AppIcon.png */; };
 		2FC3439229EE634B002D773C /* ConsentDocument.md in Resources */ = {isa = PBXBuildFile; fileRef = 2FE5DC2C29EDD78E004B9AB4 /* ConsentDocument.md */; };
@@ -47,13 +45,11 @@
 		2FE5DC6A29EDD8A9004B9AB4 /* SpeziFHIR in Frameworks */ = {isa = PBXBuildFile; productRef = 2FE5DC6929EDD8A9004B9AB4 /* SpeziFHIR */; };
 		2FE5DC6C29EDD8A9004B9AB4 /* SpeziFHIRMockDataStorageProvider in Frameworks */ = {isa = PBXBuildFile; productRef = 2FE5DC6B29EDD8A9004B9AB4 /* SpeziFHIRMockDataStorageProvider */; };
 		2FE5DC6F29EDD8BF004B9AB4 /* SpeziFHIRToFirestoreAdapter in Frameworks */ = {isa = PBXBuildFile; productRef = 2FE5DC6E29EDD8BF004B9AB4 /* SpeziFHIRToFirestoreAdapter */; };
-		2FE5DC7229EDD8D3004B9AB4 /* SpeziHealthKit in Frameworks */ = {isa = PBXBuildFile; productRef = 2FE5DC7129EDD8D3004B9AB4 /* SpeziHealthKit */; };
 		2FE5DC7529EDD8E6004B9AB4 /* SpeziFirebaseAccount in Frameworks */ = {isa = PBXBuildFile; productRef = 2FE5DC7429EDD8E6004B9AB4 /* SpeziFirebaseAccount */; };
 		2FE5DC7729EDD8E6004B9AB4 /* SpeziFirebaseConfiguration in Frameworks */ = {isa = PBXBuildFile; productRef = 2FE5DC7629EDD8E6004B9AB4 /* SpeziFirebaseConfiguration */; };
 		2FE5DC7929EDD8E6004B9AB4 /* SpeziFirestore in Frameworks */ = {isa = PBXBuildFile; productRef = 2FE5DC7829EDD8E6004B9AB4 /* SpeziFirestore */; };
 		2FE5DC7B29EDD8E6004B9AB4 /* SpeziFirestorePrefixUserIdAdapter in Frameworks */ = {isa = PBXBuildFile; productRef = 2FE5DC7A29EDD8E6004B9AB4 /* SpeziFirestorePrefixUserIdAdapter */; };
 		2FE5DC7E29EDD907004B9AB4 /* SpeziHealthKitToFHIRAdapter in Frameworks */ = {isa = PBXBuildFile; productRef = 2FE5DC7D29EDD907004B9AB4 /* SpeziHealthKitToFHIRAdapter */; };
-		2FE5DC8129EDD91D004B9AB4 /* SpeziOnboarding in Frameworks */ = {isa = PBXBuildFile; productRef = 2FE5DC8029EDD91D004B9AB4 /* SpeziOnboarding */; };
 		2FE5DC8429EDD934004B9AB4 /* SpeziQuestionnaire in Frameworks */ = {isa = PBXBuildFile; productRef = 2FE5DC8329EDD934004B9AB4 /* SpeziQuestionnaire */; };
 		2FE5DC8A29EDD972004B9AB4 /* SpeziLocalStorage in Frameworks */ = {isa = PBXBuildFile; productRef = 2FE5DC8929EDD972004B9AB4 /* SpeziLocalStorage */; };
 		2FE5DC8C29EDD972004B9AB4 /* SpeziSecureStorage in Frameworks */ = {isa = PBXBuildFile; productRef = 2FE5DC8B29EDD972004B9AB4 /* SpeziSecureStorage */; };
@@ -69,6 +65,9 @@
 		653A255528338800005D4D48 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 653A255428338800005D4D48 /* Assets.xcassets */; };
 		653A256228338800005D4D48 /* TemplateApplicationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 653A256128338800005D4D48 /* TemplateApplicationTests.swift */; };
 		653A256C28338800005D4D48 /* SchedulerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 653A256B28338800005D4D48 /* SchedulerTests.swift */; };
+		970563162A532BFC005BB074 /* SpeziHealthKit in Frameworks */ = {isa = PBXBuildFile; productRef = 970563152A532BFC005BB074 /* SpeziHealthKit */; };
+		970563192A532C6A005BB074 /* SpeziScheduler in Frameworks */ = {isa = PBXBuildFile; productRef = 970563182A532C6A005BB074 /* SpeziScheduler */; };
+		9705631C2A532C87005BB074 /* SpeziOnboarding in Frameworks */ = {isa = PBXBuildFile; productRef = 9705631B2A532C87005BB074 /* SpeziOnboarding */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -149,16 +148,15 @@
 				2FE5DC8A29EDD972004B9AB4 /* SpeziLocalStorage in Frameworks */,
 				2FE5DC8C29EDD972004B9AB4 /* SpeziSecureStorage in Frameworks */,
 				2FE5DC6F29EDD8BF004B9AB4 /* SpeziFHIRToFirestoreAdapter in Frameworks */,
+				970563162A532BFC005BB074 /* SpeziHealthKit in Frameworks */,
 				2FE5DC7529EDD8E6004B9AB4 /* SpeziFirebaseAccount in Frameworks */,
-				2FE5DC7229EDD8D3004B9AB4 /* SpeziHealthKit in Frameworks */,
 				2FE5DC7B29EDD8E6004B9AB4 /* SpeziFirestorePrefixUserIdAdapter in Frameworks */,
+				9705631C2A532C87005BB074 /* SpeziOnboarding in Frameworks */,
 				2FE5DC7E29EDD907004B9AB4 /* SpeziHealthKitToFHIRAdapter in Frameworks */,
 				2F49B7762980407C00BCB272 /* Spezi in Frameworks */,
 				2FE5DC8F29EDD980004B9AB4 /* SpeziViews in Frameworks */,
-				2F3D4ABC2A4E7C290068FB2F /* SpeziScheduler in Frameworks */,
 				2FE5DC6A29EDD8A9004B9AB4 /* SpeziFHIR in Frameworks */,
-				2FE5DC8129EDD91D004B9AB4 /* SpeziOnboarding in Frameworks */,
-				2FBD738C2A3BD150004228E7 /* SpeziScheduler in Frameworks */,
+				970563192A532C6A005BB074 /* SpeziScheduler in Frameworks */,
 				2FE5DC6C29EDD8A9004B9AB4 /* SpeziFHIRMockDataStorageProvider in Frameworks */,
 				2FE5DC7929EDD8E6004B9AB4 /* SpeziFirestore in Frameworks */,
 				2FE5DC7729EDD8E6004B9AB4 /* SpeziFirebaseConfiguration in Frameworks */,
@@ -373,19 +371,18 @@
 				2FE5DC6929EDD8A9004B9AB4 /* SpeziFHIR */,
 				2FE5DC6B29EDD8A9004B9AB4 /* SpeziFHIRMockDataStorageProvider */,
 				2FE5DC6E29EDD8BF004B9AB4 /* SpeziFHIRToFirestoreAdapter */,
-				2FE5DC7129EDD8D3004B9AB4 /* SpeziHealthKit */,
 				2FE5DC7429EDD8E6004B9AB4 /* SpeziFirebaseAccount */,
 				2FE5DC7629EDD8E6004B9AB4 /* SpeziFirebaseConfiguration */,
 				2FE5DC7829EDD8E6004B9AB4 /* SpeziFirestore */,
 				2FE5DC7A29EDD8E6004B9AB4 /* SpeziFirestorePrefixUserIdAdapter */,
 				2FE5DC7D29EDD907004B9AB4 /* SpeziHealthKitToFHIRAdapter */,
-				2FE5DC8029EDD91D004B9AB4 /* SpeziOnboarding */,
 				2FE5DC8329EDD934004B9AB4 /* SpeziQuestionnaire */,
 				2FE5DC8929EDD972004B9AB4 /* SpeziLocalStorage */,
 				2FE5DC8B29EDD972004B9AB4 /* SpeziSecureStorage */,
 				2FE5DC8E29EDD980004B9AB4 /* SpeziViews */,
-				2FBD738B2A3BD150004228E7 /* SpeziScheduler */,
-				2F3D4ABB2A4E7C290068FB2F /* SpeziScheduler */,
+				970563152A532BFC005BB074 /* SpeziHealthKit */,
+				970563182A532C6A005BB074 /* SpeziScheduler */,
+				9705631B2A532C87005BB074 /* SpeziOnboarding */,
 			);
 			productName = TemplateApplication;
 			productReference = 653A254D283387FE005D4D48 /* TemplateApplication.app */;
@@ -469,17 +466,17 @@
 				2FE5DC6529EDD894004B9AB4 /* XCRemoteSwiftPackageReference "SpeziContact" */,
 				2FE5DC6829EDD8A9004B9AB4 /* XCRemoteSwiftPackageReference "SpeziFHIR" */,
 				2FE5DC6D29EDD8BF004B9AB4 /* XCRemoteSwiftPackageReference "SpeziFHIRtoFirestoreAdapter" */,
-				2FE5DC7029EDD8D3004B9AB4 /* XCRemoteSwiftPackageReference "SpeziHealthKit" */,
 				2FE5DC7329EDD8E6004B9AB4 /* XCRemoteSwiftPackageReference "SpeziFirebase" */,
 				2FE5DC7C29EDD907004B9AB4 /* XCRemoteSwiftPackageReference "SpeziHealthKitToFHIRAdapter" */,
-				2FE5DC7F29EDD91D004B9AB4 /* XCRemoteSwiftPackageReference "SpeziOnboarding" */,
 				2FE5DC8229EDD934004B9AB4 /* XCRemoteSwiftPackageReference "SpeziQuestionnaire" */,
 				2FE5DC8829EDD972004B9AB4 /* XCRemoteSwiftPackageReference "SpeziStorage" */,
 				2FE5DC8D29EDD980004B9AB4 /* XCRemoteSwiftPackageReference "SpeziViews" */,
 				2FE5DC9029EDD9C3004B9AB4 /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */,
 				2FE5DC9729EDD9D9004B9AB4 /* XCRemoteSwiftPackageReference "XCTestExtensions" */,
 				2FE5DC9A29EDD9EF004B9AB4 /* XCRemoteSwiftPackageReference "XCTHealthKit" */,
-				2F3D4ABA2A4E7C290068FB2F /* XCRemoteSwiftPackageReference "SpeziScheduler" */,
+				970563142A532BFC005BB074 /* XCRemoteSwiftPackageReference "SpeziHealthKit" */,
+				970563172A532C6A005BB074 /* XCRemoteSwiftPackageReference "SpeziScheduler" */,
+				9705631A2A532C87005BB074 /* XCRemoteSwiftPackageReference "SpeziOnboarding" */,
 			);
 			productRefGroup = 653A254E283387FE005D4D48 /* Products */;
 			projectDirPath = "";
@@ -1066,14 +1063,6 @@
 /* End XCConfigurationList section */
 
 /* Begin XCRemoteSwiftPackageReference section */
-		2F3D4ABA2A4E7C290068FB2F /* XCRemoteSwiftPackageReference "SpeziScheduler" */ = {
-			isa = XCRemoteSwiftPackageReference;
-			repositoryURL = "https://github.com/StanfordSpezi/SpeziScheduler.git";
-			requirement = {
-				kind = upToNextMinorVersion;
-				minimumVersion = 0.4.4;
-			};
-		};
 		2F49B7742980407B00BCB272 /* XCRemoteSwiftPackageReference "Spezi" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/StanfordSpezi/Spezi";
@@ -1114,14 +1103,6 @@
 				minimumVersion = 0.3.0;
 			};
 		};
-		2FE5DC7029EDD8D3004B9AB4 /* XCRemoteSwiftPackageReference "SpeziHealthKit" */ = {
-			isa = XCRemoteSwiftPackageReference;
-			repositoryURL = "https://github.com/StanfordSpezi/SpeziHealthKit.git";
-			requirement = {
-				kind = upToNextMinorVersion;
-				minimumVersion = 0.2.1;
-			};
-		};
 		2FE5DC7329EDD8E6004B9AB4 /* XCRemoteSwiftPackageReference "SpeziFirebase" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/StanfordSpezi/SpeziFirebase.git";
@@ -1133,14 +1114,6 @@
 		2FE5DC7C29EDD907004B9AB4 /* XCRemoteSwiftPackageReference "SpeziHealthKitToFHIRAdapter" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/StanfordSpezi/SpeziHealthKitToFHIRAdapter.git";
-			requirement = {
-				kind = upToNextMinorVersion;
-				minimumVersion = 0.3.0;
-			};
-		};
-		2FE5DC7F29EDD91D004B9AB4 /* XCRemoteSwiftPackageReference "SpeziOnboarding" */ = {
-			isa = XCRemoteSwiftPackageReference;
-			repositoryURL = "https://github.com/StanfordSpezi/SpeziOnboarding.git";
 			requirement = {
 				kind = upToNextMinorVersion;
 				minimumVersion = 0.3.0;
@@ -1194,22 +1167,37 @@
 				minimumVersion = 0.3.3;
 			};
 		};
+		970563142A532BFC005BB074 /* XCRemoteSwiftPackageReference "SpeziHealthKit" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/StanfordSpezi/SpeziHealthKit";
+			requirement = {
+				branch = "feature/determine-health-authorizations-given";
+				kind = branch;
+			};
+		};
+		970563172A532C6A005BB074 /* XCRemoteSwiftPackageReference "SpeziScheduler" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/StanfordSpezi/SpeziScheduler";
+			requirement = {
+				branch = "feat/flag-determining-notification-auth";
+				kind = branch;
+			};
+		};
+		9705631A2A532C87005BB074 /* XCRemoteSwiftPackageReference "SpeziOnboarding" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/StanfordSpezi/SpeziOnboarding";
+			requirement = {
+				branch = "feat/allow-async-action-OnboardingActionsView";
+				kind = branch;
+			};
+		};
 /* End XCRemoteSwiftPackageReference section */
 
 /* Begin XCSwiftPackageProductDependency section */
-		2F3D4ABB2A4E7C290068FB2F /* SpeziScheduler */ = {
-			isa = XCSwiftPackageProductDependency;
-			package = 2F3D4ABA2A4E7C290068FB2F /* XCRemoteSwiftPackageReference "SpeziScheduler" */;
-			productName = SpeziScheduler;
-		};
 		2F49B7752980407B00BCB272 /* Spezi */ = {
 			isa = XCSwiftPackageProductDependency;
 			package = 2F49B7742980407B00BCB272 /* XCRemoteSwiftPackageReference "Spezi" */;
 			productName = Spezi;
-		};
-		2FBD738B2A3BD150004228E7 /* SpeziScheduler */ = {
-			isa = XCSwiftPackageProductDependency;
-			productName = SpeziScheduler;
 		};
 		2FE5DC6329EDD883004B9AB4 /* SpeziAccount */ = {
 			isa = XCSwiftPackageProductDependency;
@@ -1236,11 +1224,6 @@
 			package = 2FE5DC6D29EDD8BF004B9AB4 /* XCRemoteSwiftPackageReference "SpeziFHIRtoFirestoreAdapter" */;
 			productName = SpeziFHIRToFirestoreAdapter;
 		};
-		2FE5DC7129EDD8D3004B9AB4 /* SpeziHealthKit */ = {
-			isa = XCSwiftPackageProductDependency;
-			package = 2FE5DC7029EDD8D3004B9AB4 /* XCRemoteSwiftPackageReference "SpeziHealthKit" */;
-			productName = SpeziHealthKit;
-		};
 		2FE5DC7429EDD8E6004B9AB4 /* SpeziFirebaseAccount */ = {
 			isa = XCSwiftPackageProductDependency;
 			package = 2FE5DC7329EDD8E6004B9AB4 /* XCRemoteSwiftPackageReference "SpeziFirebase" */;
@@ -1265,11 +1248,6 @@
 			isa = XCSwiftPackageProductDependency;
 			package = 2FE5DC7C29EDD907004B9AB4 /* XCRemoteSwiftPackageReference "SpeziHealthKitToFHIRAdapter" */;
 			productName = SpeziHealthKitToFHIRAdapter;
-		};
-		2FE5DC8029EDD91D004B9AB4 /* SpeziOnboarding */ = {
-			isa = XCSwiftPackageProductDependency;
-			package = 2FE5DC7F29EDD91D004B9AB4 /* XCRemoteSwiftPackageReference "SpeziOnboarding" */;
-			productName = SpeziOnboarding;
 		};
 		2FE5DC8329EDD934004B9AB4 /* SpeziQuestionnaire */ = {
 			isa = XCSwiftPackageProductDependency;
@@ -1300,6 +1278,21 @@
 			isa = XCSwiftPackageProductDependency;
 			package = 2FE5DC9A29EDD9EF004B9AB4 /* XCRemoteSwiftPackageReference "XCTHealthKit" */;
 			productName = XCTHealthKit;
+		};
+		970563152A532BFC005BB074 /* SpeziHealthKit */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 970563142A532BFC005BB074 /* XCRemoteSwiftPackageReference "SpeziHealthKit" */;
+			productName = SpeziHealthKit;
+		};
+		970563182A532C6A005BB074 /* SpeziScheduler */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 970563172A532C6A005BB074 /* XCRemoteSwiftPackageReference "SpeziScheduler" */;
+			productName = SpeziScheduler;
+		};
+		9705631B2A532C87005BB074 /* SpeziOnboarding */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 9705631A2A532C87005BB074 /* XCRemoteSwiftPackageReference "SpeziOnboarding" */;
+			productName = SpeziOnboarding;
 		};
 /* End XCSwiftPackageProductDependency section */
 	};

--- a/TemplateApplication.xcodeproj/project.pbxproj
+++ b/TemplateApplication.xcodeproj/project.pbxproj
@@ -9,6 +9,7 @@
 /* Begin PBXBuildFile section */
 		27FA29902A388E9B009CAC45 /* ModalView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 27FA298F2A388E9B009CAC45 /* ModalView.swift */; };
 		2F1B52CE2A4F5CCE003AE151 /* MockUploadTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F1B52CD2A4F5CCE003AE151 /* MockUploadTests.swift */; };
+		2F3D4ABC2A4E7C290068FB2F /* SpeziScheduler in Frameworks */ = {isa = PBXBuildFile; productRef = 2F3D4ABB2A4E7C290068FB2F /* SpeziScheduler */; };
 		2F49B7762980407C00BCB272 /* Spezi in Frameworks */ = {isa = PBXBuildFile; productRef = 2F49B7752980407B00BCB272 /* Spezi */; };
 		2F4E237E2989A2FE0013F3D9 /* OnboardingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F4E237D2989A2FE0013F3D9 /* OnboardingTests.swift */; };
 		2F4E23832989D51F0013F3D9 /* TemplateAppTestingSetup.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F4E23822989D51F0013F3D9 /* TemplateAppTestingSetup.swift */; };
@@ -17,6 +18,7 @@
 		2F5E32BD297E05EA003432F8 /* TemplateAppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F5E32BC297E05EA003432F8 /* TemplateAppDelegate.swift */; };
 		2F6025CB29BBE70F0045459E /* GoogleService-Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = 2F6025CA29BBE70F0045459E /* GoogleService-Info.plist */; };
 		2F65B44E2A3B8B0600A36932 /* NotificationPermissions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F65B44D2A3B8B0600A36932 /* NotificationPermissions.swift */; };
+		2FBD738C2A3BD150004228E7 /* SpeziScheduler in Frameworks */ = {isa = PBXBuildFile; productRef = 2FBD738B2A3BD150004228E7 /* SpeziScheduler */; };
 		2FC3439029EE6346002D773C /* SocialSupportQuestionnaire.json in Resources */ = {isa = PBXBuildFile; fileRef = 2FE5DC5529EDD811004B9AB4 /* SocialSupportQuestionnaire.json */; };
 		2FC3439129EE6349002D773C /* AppIcon.png in Resources */ = {isa = PBXBuildFile; fileRef = 2FE5DC2A29EDD78D004B9AB4 /* AppIcon.png */; };
 		2FC3439229EE634B002D773C /* ConsentDocument.md in Resources */ = {isa = PBXBuildFile; fileRef = 2FE5DC2C29EDD78E004B9AB4 /* ConsentDocument.md */; };
@@ -45,11 +47,13 @@
 		2FE5DC6A29EDD8A9004B9AB4 /* SpeziFHIR in Frameworks */ = {isa = PBXBuildFile; productRef = 2FE5DC6929EDD8A9004B9AB4 /* SpeziFHIR */; };
 		2FE5DC6C29EDD8A9004B9AB4 /* SpeziFHIRMockDataStorageProvider in Frameworks */ = {isa = PBXBuildFile; productRef = 2FE5DC6B29EDD8A9004B9AB4 /* SpeziFHIRMockDataStorageProvider */; };
 		2FE5DC6F29EDD8BF004B9AB4 /* SpeziFHIRToFirestoreAdapter in Frameworks */ = {isa = PBXBuildFile; productRef = 2FE5DC6E29EDD8BF004B9AB4 /* SpeziFHIRToFirestoreAdapter */; };
+		2FE5DC7229EDD8D3004B9AB4 /* SpeziHealthKit in Frameworks */ = {isa = PBXBuildFile; productRef = 2FE5DC7129EDD8D3004B9AB4 /* SpeziHealthKit */; };
 		2FE5DC7529EDD8E6004B9AB4 /* SpeziFirebaseAccount in Frameworks */ = {isa = PBXBuildFile; productRef = 2FE5DC7429EDD8E6004B9AB4 /* SpeziFirebaseAccount */; };
 		2FE5DC7729EDD8E6004B9AB4 /* SpeziFirebaseConfiguration in Frameworks */ = {isa = PBXBuildFile; productRef = 2FE5DC7629EDD8E6004B9AB4 /* SpeziFirebaseConfiguration */; };
 		2FE5DC7929EDD8E6004B9AB4 /* SpeziFirestore in Frameworks */ = {isa = PBXBuildFile; productRef = 2FE5DC7829EDD8E6004B9AB4 /* SpeziFirestore */; };
 		2FE5DC7B29EDD8E6004B9AB4 /* SpeziFirestorePrefixUserIdAdapter in Frameworks */ = {isa = PBXBuildFile; productRef = 2FE5DC7A29EDD8E6004B9AB4 /* SpeziFirestorePrefixUserIdAdapter */; };
 		2FE5DC7E29EDD907004B9AB4 /* SpeziHealthKitToFHIRAdapter in Frameworks */ = {isa = PBXBuildFile; productRef = 2FE5DC7D29EDD907004B9AB4 /* SpeziHealthKitToFHIRAdapter */; };
+		2FE5DC8129EDD91D004B9AB4 /* SpeziOnboarding in Frameworks */ = {isa = PBXBuildFile; productRef = 2FE5DC8029EDD91D004B9AB4 /* SpeziOnboarding */; };
 		2FE5DC8429EDD934004B9AB4 /* SpeziQuestionnaire in Frameworks */ = {isa = PBXBuildFile; productRef = 2FE5DC8329EDD934004B9AB4 /* SpeziQuestionnaire */; };
 		2FE5DC8A29EDD972004B9AB4 /* SpeziLocalStorage in Frameworks */ = {isa = PBXBuildFile; productRef = 2FE5DC8929EDD972004B9AB4 /* SpeziLocalStorage */; };
 		2FE5DC8C29EDD972004B9AB4 /* SpeziSecureStorage in Frameworks */ = {isa = PBXBuildFile; productRef = 2FE5DC8B29EDD972004B9AB4 /* SpeziSecureStorage */; };
@@ -65,9 +69,6 @@
 		653A255528338800005D4D48 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 653A255428338800005D4D48 /* Assets.xcassets */; };
 		653A256228338800005D4D48 /* TemplateApplicationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 653A256128338800005D4D48 /* TemplateApplicationTests.swift */; };
 		653A256C28338800005D4D48 /* SchedulerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 653A256B28338800005D4D48 /* SchedulerTests.swift */; };
-		970563162A532BFC005BB074 /* SpeziHealthKit in Frameworks */ = {isa = PBXBuildFile; productRef = 970563152A532BFC005BB074 /* SpeziHealthKit */; };
-		970563192A532C6A005BB074 /* SpeziScheduler in Frameworks */ = {isa = PBXBuildFile; productRef = 970563182A532C6A005BB074 /* SpeziScheduler */; };
-		9705631C2A532C87005BB074 /* SpeziOnboarding in Frameworks */ = {isa = PBXBuildFile; productRef = 9705631B2A532C87005BB074 /* SpeziOnboarding */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -148,15 +149,16 @@
 				2FE5DC8A29EDD972004B9AB4 /* SpeziLocalStorage in Frameworks */,
 				2FE5DC8C29EDD972004B9AB4 /* SpeziSecureStorage in Frameworks */,
 				2FE5DC6F29EDD8BF004B9AB4 /* SpeziFHIRToFirestoreAdapter in Frameworks */,
-				970563162A532BFC005BB074 /* SpeziHealthKit in Frameworks */,
 				2FE5DC7529EDD8E6004B9AB4 /* SpeziFirebaseAccount in Frameworks */,
+				2FE5DC7229EDD8D3004B9AB4 /* SpeziHealthKit in Frameworks */,
 				2FE5DC7B29EDD8E6004B9AB4 /* SpeziFirestorePrefixUserIdAdapter in Frameworks */,
-				9705631C2A532C87005BB074 /* SpeziOnboarding in Frameworks */,
 				2FE5DC7E29EDD907004B9AB4 /* SpeziHealthKitToFHIRAdapter in Frameworks */,
 				2F49B7762980407C00BCB272 /* Spezi in Frameworks */,
 				2FE5DC8F29EDD980004B9AB4 /* SpeziViews in Frameworks */,
+				2F3D4ABC2A4E7C290068FB2F /* SpeziScheduler in Frameworks */,
 				2FE5DC6A29EDD8A9004B9AB4 /* SpeziFHIR in Frameworks */,
-				970563192A532C6A005BB074 /* SpeziScheduler in Frameworks */,
+				2FE5DC8129EDD91D004B9AB4 /* SpeziOnboarding in Frameworks */,
+				2FBD738C2A3BD150004228E7 /* SpeziScheduler in Frameworks */,
 				2FE5DC6C29EDD8A9004B9AB4 /* SpeziFHIRMockDataStorageProvider in Frameworks */,
 				2FE5DC7929EDD8E6004B9AB4 /* SpeziFirestore in Frameworks */,
 				2FE5DC7729EDD8E6004B9AB4 /* SpeziFirebaseConfiguration in Frameworks */,
@@ -371,18 +373,19 @@
 				2FE5DC6929EDD8A9004B9AB4 /* SpeziFHIR */,
 				2FE5DC6B29EDD8A9004B9AB4 /* SpeziFHIRMockDataStorageProvider */,
 				2FE5DC6E29EDD8BF004B9AB4 /* SpeziFHIRToFirestoreAdapter */,
+				2FE5DC7129EDD8D3004B9AB4 /* SpeziHealthKit */,
 				2FE5DC7429EDD8E6004B9AB4 /* SpeziFirebaseAccount */,
 				2FE5DC7629EDD8E6004B9AB4 /* SpeziFirebaseConfiguration */,
 				2FE5DC7829EDD8E6004B9AB4 /* SpeziFirestore */,
 				2FE5DC7A29EDD8E6004B9AB4 /* SpeziFirestorePrefixUserIdAdapter */,
 				2FE5DC7D29EDD907004B9AB4 /* SpeziHealthKitToFHIRAdapter */,
+				2FE5DC8029EDD91D004B9AB4 /* SpeziOnboarding */,
 				2FE5DC8329EDD934004B9AB4 /* SpeziQuestionnaire */,
 				2FE5DC8929EDD972004B9AB4 /* SpeziLocalStorage */,
 				2FE5DC8B29EDD972004B9AB4 /* SpeziSecureStorage */,
 				2FE5DC8E29EDD980004B9AB4 /* SpeziViews */,
-				970563152A532BFC005BB074 /* SpeziHealthKit */,
-				970563182A532C6A005BB074 /* SpeziScheduler */,
-				9705631B2A532C87005BB074 /* SpeziOnboarding */,
+				2FBD738B2A3BD150004228E7 /* SpeziScheduler */,
+				2F3D4ABB2A4E7C290068FB2F /* SpeziScheduler */,
 			);
 			productName = TemplateApplication;
 			productReference = 653A254D283387FE005D4D48 /* TemplateApplication.app */;
@@ -466,17 +469,17 @@
 				2FE5DC6529EDD894004B9AB4 /* XCRemoteSwiftPackageReference "SpeziContact" */,
 				2FE5DC6829EDD8A9004B9AB4 /* XCRemoteSwiftPackageReference "SpeziFHIR" */,
 				2FE5DC6D29EDD8BF004B9AB4 /* XCRemoteSwiftPackageReference "SpeziFHIRtoFirestoreAdapter" */,
+				2FE5DC7029EDD8D3004B9AB4 /* XCRemoteSwiftPackageReference "SpeziHealthKit" */,
 				2FE5DC7329EDD8E6004B9AB4 /* XCRemoteSwiftPackageReference "SpeziFirebase" */,
 				2FE5DC7C29EDD907004B9AB4 /* XCRemoteSwiftPackageReference "SpeziHealthKitToFHIRAdapter" */,
+				2FE5DC7F29EDD91D004B9AB4 /* XCRemoteSwiftPackageReference "SpeziOnboarding" */,
 				2FE5DC8229EDD934004B9AB4 /* XCRemoteSwiftPackageReference "SpeziQuestionnaire" */,
 				2FE5DC8829EDD972004B9AB4 /* XCRemoteSwiftPackageReference "SpeziStorage" */,
 				2FE5DC8D29EDD980004B9AB4 /* XCRemoteSwiftPackageReference "SpeziViews" */,
 				2FE5DC9029EDD9C3004B9AB4 /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */,
 				2FE5DC9729EDD9D9004B9AB4 /* XCRemoteSwiftPackageReference "XCTestExtensions" */,
 				2FE5DC9A29EDD9EF004B9AB4 /* XCRemoteSwiftPackageReference "XCTHealthKit" */,
-				970563142A532BFC005BB074 /* XCRemoteSwiftPackageReference "SpeziHealthKit" */,
-				970563172A532C6A005BB074 /* XCRemoteSwiftPackageReference "SpeziScheduler" */,
-				9705631A2A532C87005BB074 /* XCRemoteSwiftPackageReference "SpeziOnboarding" */,
+				2F3D4ABA2A4E7C290068FB2F /* XCRemoteSwiftPackageReference "SpeziScheduler" */,
 			);
 			productRefGroup = 653A254E283387FE005D4D48 /* Products */;
 			projectDirPath = "";
@@ -1063,6 +1066,14 @@
 /* End XCConfigurationList section */
 
 /* Begin XCRemoteSwiftPackageReference section */
+		2F3D4ABA2A4E7C290068FB2F /* XCRemoteSwiftPackageReference "SpeziScheduler" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/StanfordSpezi/SpeziScheduler.git";
+			requirement = {
+				kind = upToNextMinorVersion;
+				minimumVersion = 0.4.5;
+			};
+		};
 		2F49B7742980407B00BCB272 /* XCRemoteSwiftPackageReference "Spezi" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/StanfordSpezi/Spezi";
@@ -1103,6 +1114,14 @@
 				minimumVersion = 0.3.0;
 			};
 		};
+		2FE5DC7029EDD8D3004B9AB4 /* XCRemoteSwiftPackageReference "SpeziHealthKit" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/StanfordSpezi/SpeziHealthKit.git";
+			requirement = {
+				kind = upToNextMinorVersion;
+				minimumVersion = 0.2.2;
+			};
+		};
 		2FE5DC7329EDD8E6004B9AB4 /* XCRemoteSwiftPackageReference "SpeziFirebase" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/StanfordSpezi/SpeziFirebase.git";
@@ -1117,6 +1136,14 @@
 			requirement = {
 				kind = upToNextMinorVersion;
 				minimumVersion = 0.3.0;
+			};
+		};
+		2FE5DC7F29EDD91D004B9AB4 /* XCRemoteSwiftPackageReference "SpeziOnboarding" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/StanfordSpezi/SpeziOnboarding.git";
+			requirement = {
+				kind = upToNextMinorVersion;
+				minimumVersion = 0.3.1;
 			};
 		};
 		2FE5DC8229EDD934004B9AB4 /* XCRemoteSwiftPackageReference "SpeziQuestionnaire" */ = {
@@ -1156,7 +1183,7 @@
 			repositoryURL = "https://github.com/StanfordBDHG/XCTestExtensions.git";
 			requirement = {
 				kind = upToNextMinorVersion;
-				minimumVersion = 0.4.2;
+				minimumVersion = 0.4.6;
 			};
 		};
 		2FE5DC9A29EDD9EF004B9AB4 /* XCRemoteSwiftPackageReference "XCTHealthKit" */ = {
@@ -1164,40 +1191,25 @@
 			repositoryURL = "https://github.com/StanfordBDHG/XCTHealthKit.git";
 			requirement = {
 				kind = upToNextMinorVersion;
-				minimumVersion = 0.3.3;
-			};
-		};
-		970563142A532BFC005BB074 /* XCRemoteSwiftPackageReference "SpeziHealthKit" */ = {
-			isa = XCRemoteSwiftPackageReference;
-			repositoryURL = "https://github.com/StanfordSpezi/SpeziHealthKit";
-			requirement = {
-				branch = "feature/determine-health-authorizations-given";
-				kind = branch;
-			};
-		};
-		970563172A532C6A005BB074 /* XCRemoteSwiftPackageReference "SpeziScheduler" */ = {
-			isa = XCRemoteSwiftPackageReference;
-			repositoryURL = "https://github.com/StanfordSpezi/SpeziScheduler";
-			requirement = {
-				branch = "feat/flag-determining-notification-auth";
-				kind = branch;
-			};
-		};
-		9705631A2A532C87005BB074 /* XCRemoteSwiftPackageReference "SpeziOnboarding" */ = {
-			isa = XCRemoteSwiftPackageReference;
-			repositoryURL = "https://github.com/StanfordSpezi/SpeziOnboarding";
-			requirement = {
-				branch = "feat/allow-async-action-OnboardingActionsView";
-				kind = branch;
+				minimumVersion = 0.3.5;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */
 
 /* Begin XCSwiftPackageProductDependency section */
+		2F3D4ABB2A4E7C290068FB2F /* SpeziScheduler */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 2F3D4ABA2A4E7C290068FB2F /* XCRemoteSwiftPackageReference "SpeziScheduler" */;
+			productName = SpeziScheduler;
+		};
 		2F49B7752980407B00BCB272 /* Spezi */ = {
 			isa = XCSwiftPackageProductDependency;
 			package = 2F49B7742980407B00BCB272 /* XCRemoteSwiftPackageReference "Spezi" */;
 			productName = Spezi;
+		};
+		2FBD738B2A3BD150004228E7 /* SpeziScheduler */ = {
+			isa = XCSwiftPackageProductDependency;
+			productName = SpeziScheduler;
 		};
 		2FE5DC6329EDD883004B9AB4 /* SpeziAccount */ = {
 			isa = XCSwiftPackageProductDependency;
@@ -1224,6 +1236,11 @@
 			package = 2FE5DC6D29EDD8BF004B9AB4 /* XCRemoteSwiftPackageReference "SpeziFHIRtoFirestoreAdapter" */;
 			productName = SpeziFHIRToFirestoreAdapter;
 		};
+		2FE5DC7129EDD8D3004B9AB4 /* SpeziHealthKit */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 2FE5DC7029EDD8D3004B9AB4 /* XCRemoteSwiftPackageReference "SpeziHealthKit" */;
+			productName = SpeziHealthKit;
+		};
 		2FE5DC7429EDD8E6004B9AB4 /* SpeziFirebaseAccount */ = {
 			isa = XCSwiftPackageProductDependency;
 			package = 2FE5DC7329EDD8E6004B9AB4 /* XCRemoteSwiftPackageReference "SpeziFirebase" */;
@@ -1248,6 +1265,11 @@
 			isa = XCSwiftPackageProductDependency;
 			package = 2FE5DC7C29EDD907004B9AB4 /* XCRemoteSwiftPackageReference "SpeziHealthKitToFHIRAdapter" */;
 			productName = SpeziHealthKitToFHIRAdapter;
+		};
+		2FE5DC8029EDD91D004B9AB4 /* SpeziOnboarding */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 2FE5DC7F29EDD91D004B9AB4 /* XCRemoteSwiftPackageReference "SpeziOnboarding" */;
+			productName = SpeziOnboarding;
 		};
 		2FE5DC8329EDD934004B9AB4 /* SpeziQuestionnaire */ = {
 			isa = XCSwiftPackageProductDependency;
@@ -1278,21 +1300,6 @@
 			isa = XCSwiftPackageProductDependency;
 			package = 2FE5DC9A29EDD9EF004B9AB4 /* XCRemoteSwiftPackageReference "XCTHealthKit" */;
 			productName = XCTHealthKit;
-		};
-		970563152A532BFC005BB074 /* SpeziHealthKit */ = {
-			isa = XCSwiftPackageProductDependency;
-			package = 970563142A532BFC005BB074 /* XCRemoteSwiftPackageReference "SpeziHealthKit" */;
-			productName = SpeziHealthKit;
-		};
-		970563182A532C6A005BB074 /* SpeziScheduler */ = {
-			isa = XCSwiftPackageProductDependency;
-			package = 970563172A532C6A005BB074 /* XCRemoteSwiftPackageReference "SpeziScheduler" */;
-			productName = SpeziScheduler;
-		};
-		9705631B2A532C87005BB074 /* SpeziOnboarding */ = {
-			isa = XCSwiftPackageProductDependency;
-			package = 9705631A2A532C87005BB074 /* XCRemoteSwiftPackageReference "SpeziOnboarding" */;
-			productName = SpeziOnboarding;
 		};
 /* End XCSwiftPackageProductDependency section */
 	};

--- a/TemplateApplication.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/TemplateApplication.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -183,10 +183,10 @@
     {
       "identity" : "spezihealthkit",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/StanfordSpezi/SpeziHealthKit.git",
+      "location" : "https://github.com/StanfordSpezi/SpeziHealthKit",
       "state" : {
-        "revision" : "7ae7c344c052fb7bdc9490cb4296b87a0abb8326",
-        "version" : "0.2.1"
+        "branch" : "feature/determine-health-authorizations-given",
+        "revision" : "0364392a459c0c0139aad4224d5d935460b45bf3"
       }
     },
     {
@@ -201,10 +201,10 @@
     {
       "identity" : "spezionboarding",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/StanfordSpezi/SpeziOnboarding.git",
+      "location" : "https://github.com/StanfordSpezi/SpeziOnboarding",
       "state" : {
-        "revision" : "10109f18d7958098dbbc4c32786d237a57400f85",
-        "version" : "0.3.0"
+        "branch" : "feat/allow-async-action-OnboardingActionsView",
+        "revision" : "4c3810301fd147153a637073618a5c39c49e0f29"
       }
     },
     {
@@ -219,10 +219,10 @@
     {
       "identity" : "spezischeduler",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/StanfordSpezi/SpeziScheduler.git",
+      "location" : "https://github.com/StanfordSpezi/SpeziScheduler",
       "state" : {
-        "revision" : "cf4d9a0147b2ac16504a24a765e68c9e39afc19a",
-        "version" : "0.4.4"
+        "branch" : "feat/flag-determining-notification-auth",
+        "revision" : "311f926543e87202e49343beb5e1ff3a2ae9b2f0"
       }
     },
     {

--- a/TemplateApplication.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/TemplateApplication.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -77,8 +77,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/StanfordBDHG/HealthKitOnFHIR",
       "state" : {
-        "revision" : "d10f408766264183cd50bb117b99580255520aa3",
-        "version" : "0.2.3"
+        "revision" : "fdf8e4543718a940643598e4bd5e750e9c4c5540",
+        "version" : "0.2.4"
       }
     },
     {
@@ -183,10 +183,10 @@
     {
       "identity" : "spezihealthkit",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/StanfordSpezi/SpeziHealthKit",
+      "location" : "https://github.com/StanfordSpezi/SpeziHealthKit.git",
       "state" : {
-        "branch" : "feature/determine-health-authorizations-given",
-        "revision" : "0364392a459c0c0139aad4224d5d935460b45bf3"
+        "revision" : "0a26f415c90d586a2417f31b1444bb08e004db17",
+        "version" : "0.2.2"
       }
     },
     {
@@ -201,10 +201,10 @@
     {
       "identity" : "spezionboarding",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/StanfordSpezi/SpeziOnboarding",
+      "location" : "https://github.com/StanfordSpezi/SpeziOnboarding.git",
       "state" : {
-        "branch" : "feat/allow-async-action-OnboardingActionsView",
-        "revision" : "4c3810301fd147153a637073618a5c39c49e0f29"
+        "revision" : "a84ddd7cdb5ce48935ca3daf2a33ddc512d76b33",
+        "version" : "0.3.1"
       }
     },
     {
@@ -219,10 +219,10 @@
     {
       "identity" : "spezischeduler",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/StanfordSpezi/SpeziScheduler",
+      "location" : "https://github.com/StanfordSpezi/SpeziScheduler.git",
       "state" : {
-        "branch" : "feat/flag-determining-notification-auth",
-        "revision" : "311f926543e87202e49343beb5e1ff3a2ae9b2f0"
+        "revision" : "8688e48da3f7b9623303793042a4c48dcaaa0d49",
+        "version" : "0.4.5"
       }
     },
     {
@@ -257,8 +257,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/StanfordBDHG/XCTestExtensions.git",
       "state" : {
-        "revision" : "9b716267e7699b2ad8f0fc4a6798dd213c9b8e0a",
-        "version" : "0.4.5"
+        "revision" : "625477e0937294cb3fd6e7bbf72b78f951644b1d",
+        "version" : "0.4.6"
       }
     },
     {
@@ -266,8 +266,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/StanfordBDHG/XCTHealthKit.git",
       "state" : {
-        "revision" : "19395bbd14a2554e4c9d3fe5cf38aa626c807269",
-        "version" : "0.3.3"
+        "revision" : "6e9344a2d632b801d94fe3bbd1d891817e032103",
+        "version" : "0.3.5"
       }
     },
     {

--- a/TemplateApplication/Onboarding/AccountSetup/AccountSetup.swift
+++ b/TemplateApplication/Onboarding/AccountSetup/AccountSetup.swift
@@ -44,10 +44,7 @@ struct AccountSetup: View {
             .onReceive(account.objectWillChange) {
                 if account.signedIn {
                     Task {
-                        moveToNextOnboardingStep(
-                            healthKitAuthorized: healthKitDataSource.authorized,
-                            notificationAuthorized: await scheduler.localNotificationAuthorization
-                        )
+                        await moveToNextOnboardingStep()
                     }
                 }
             }
@@ -94,10 +91,7 @@ struct AccountSetup: View {
             OnboardingActionsView(
                 "ACCOUNT_NEXT".moduleLocalized,
                 action: {
-                    moveToNextOnboardingStep(
-                        healthKitAuthorized: healthKitDataSource.authorized,
-                        notificationAuthorized: await scheduler.localNotificationAuthorization
-                    )
+                    await moveToNextOnboardingStep()
                 }
             )
         } else {
@@ -120,10 +114,10 @@ struct AccountSetup: View {
     }
     
     
-    private func moveToNextOnboardingStep(healthKitAuthorized: Bool, notificationAuthorized: Bool) {
-        if HKHealthStore.isHealthDataAvailable() && !healthKitAuthorized {
+    private func moveToNextOnboardingStep() async {
+        if HKHealthStore.isHealthDataAvailable() && !healthKitDataSource.authorized {
             onboardingSteps.append(.healthKitPermissions)
-        } else if !notificationAuthorized {
+        } else if await !scheduler.localNotificationAuthorization {
             onboardingSteps.append(.notificationPermissions)
         } else {
             completedOnboardingFlow = true

--- a/TemplateApplication/Onboarding/AccountSetup/AccountSetup.swift
+++ b/TemplateApplication/Onboarding/AccountSetup/AccountSetup.swift
@@ -8,6 +8,7 @@
 
 import SpeziAccount
 import class SpeziFHIR.FHIR
+import SpeziHealthKit
 import FirebaseAuth
 import HealthKit
 import SpeziFirebaseAccount
@@ -18,6 +19,7 @@ import SwiftUI
 struct AccountSetup: View {
     @Binding private var onboardingSteps: [OnboardingFlow.Step]
     @EnvironmentObject var account: Account
+    @EnvironmentObject var healthKitDataSource: HealthKit<FHIR>
     
     
     var body: some View {
@@ -39,7 +41,7 @@ struct AccountSetup: View {
         )
             .onReceive(account.objectWillChange) {
                 if account.signedIn {
-                    moveToNextOnboardingStep()
+                    moveToNextOnboardingStep(healthKitAuthorized: healthKitDataSource.authorized)
                 }
             }
     }
@@ -85,7 +87,7 @@ struct AccountSetup: View {
             OnboardingActionsView(
                 "ACCOUNT_NEXT".moduleLocalized,
                 action: {
-                    moveToNextOnboardingStep()
+                    moveToNextOnboardingStep(healthKitAuthorized: healthKitDataSource.authorized)
                 }
             )
         } else {
@@ -108,9 +110,14 @@ struct AccountSetup: View {
     }
     
     
-    private func moveToNextOnboardingStep() {
+    private func moveToNextOnboardingStep(healthKitAuthorized: Bool) {
         if HKHealthStore.isHealthDataAvailable() {
             onboardingSteps.append(.healthKitPermissions)
+            if !healthKitAuthorized {
+                onboardingSteps.append(.healthKitPermissions)
+            } else {
+                onboardingSteps.append(.notificationPermissions)
+            }
         } else {
             onboardingSteps.append(.notificationPermissions)
         }

--- a/TemplateApplication/Onboarding/Consent.swift
+++ b/TemplateApplication/Onboarding/Consent.swift
@@ -6,6 +6,7 @@
 // SPDX-License-Identifier: MIT
 //
 
+import HealthKit
 import class SpeziFHIR.FHIR
 import SpeziHealthKit
 import SpeziOnboarding
@@ -42,7 +43,7 @@ struct Consent: View {
                 if !FeatureFlags.disableFirebase {
                     onboardingSteps.append(.accountSetup)
                 } else {
-                    if !healthKitDataSource.authorized {
+                    if HKHealthStore.isHealthDataAvailable() && !healthKitDataSource.authorized {
                         onboardingSteps.append(.healthKitPermissions)
                     } else if await !scheduler.localNotificationAuthorization {
                         onboardingSteps.append(.notificationPermissions)

--- a/TemplateApplication/Onboarding/Consent.swift
+++ b/TemplateApplication/Onboarding/Consent.swift
@@ -6,12 +6,16 @@
 // SPDX-License-Identifier: MIT
 //
 
+import class SpeziFHIR.FHIR
+import SpeziHealthKit
 import SpeziOnboarding
 import SwiftUI
 
 
 struct Consent: View {
     @Binding private var onboardingSteps: [OnboardingFlow.Step]
+    @EnvironmentObject var healthKitDataSource: HealthKit<FHIR>
+    @AppStorage(StorageKeys.onboardingFlowComplete) var completedOnboardingFlow = false
     
     
     private var consentDocument: Data {
@@ -37,7 +41,11 @@ struct Consent: View {
                 if !FeatureFlags.disableFirebase {
                     onboardingSteps.append(.accountSetup)
                 } else {
-                    onboardingSteps.append(.healthKitPermissions)
+                    if !healthKitDataSource.authorized {
+                        onboardingSteps.append(.healthKitPermissions)
+                    } else {
+                        completedOnboardingFlow = true
+                    }
                 }
             }
         )

--- a/TemplateApplication/Onboarding/Consent.swift
+++ b/TemplateApplication/Onboarding/Consent.swift
@@ -15,6 +15,7 @@ import SwiftUI
 struct Consent: View {
     @Binding private var onboardingSteps: [OnboardingFlow.Step]
     @EnvironmentObject var healthKitDataSource: HealthKit<FHIR>
+    @EnvironmentObject var scheduler: TemplateApplicationScheduler
     @AppStorage(StorageKeys.onboardingFlowComplete) var completedOnboardingFlow = false
     
     
@@ -43,6 +44,8 @@ struct Consent: View {
                 } else {
                     if !healthKitDataSource.authorized {
                         onboardingSteps.append(.healthKitPermissions)
+                    } else if await !scheduler.localNotificationAuthorization {
+                        onboardingSteps.append(.notificationPermissions)
                     } else {
                         completedOnboardingFlow = true
                     }

--- a/TemplateApplication/Onboarding/HealthKitPermissions.swift
+++ b/TemplateApplication/Onboarding/HealthKitPermissions.swift
@@ -14,8 +14,10 @@ import SwiftUI
 
 struct HealthKitPermissions: View {
     @EnvironmentObject var healthKitDataSource: HealthKit<FHIR>
+    @EnvironmentObject var scheduler: TemplateApplicationScheduler
     @Binding private var onboardingSteps: [OnboardingFlow.Step]
     @State var healthKitProcessing = false
+    @AppStorage(StorageKeys.onboardingFlowComplete) var completedOnboardingFlow = false
     
     
     var body: some View {
@@ -51,7 +53,11 @@ struct HealthKitPermissions: View {
                             print("Could not request HealthKit permissions.")
                         }
                         healthKitProcessing = false
-                        onboardingSteps.append(.notificationPermissions)
+                        if await !scheduler.localNotificationAuthorization {
+                            onboardingSteps.append(.notificationPermissions)
+                        } else {
+                            completedOnboardingFlow = true
+                        }
                     }
                 )
             }

--- a/TemplateApplicationUITests/OnboardingTests.swift
+++ b/TemplateApplicationUITests/OnboardingTests.swift
@@ -30,10 +30,24 @@ class OnboardingTests: XCTestCase {
         
         try app.navigateOnboardingFlow()
         
-        let tabBar = app.tabBars["Tab Bar"]
-        XCTAssertTrue(tabBar.buttons["Schedule"].waitForExistence(timeout: 2))
-        XCTAssertTrue(tabBar.buttons["Contacts"].waitForExistence(timeout: 2))
-        XCTAssertTrue(tabBar.buttons["Mock Upload"].waitForExistence(timeout: 2))
+        try app.assertOnboardingComplete()
+    }
+    
+    func testOnboardingFlowRepeated() throws {
+        let app = XCUIApplication()
+        app.launchArguments = ["--showOnboarding"]
+        
+        try app.navigateOnboardingFlow()
+        try app.assertOnboardingComplete()
+        
+        app.terminate()
+        
+        // Second onboarding round shouldn't display HealthKit and Notification authorizations anymore
+        app.activate()
+        
+        try app.navigateOnboardingFlow(repeated: true)
+        // Do not show HealthKit and Notification authorization view again
+        try app.assertOnboardingComplete()
     }
 }
 
@@ -47,15 +61,17 @@ extension XCUIApplication {
         }
     }
     
-    fileprivate func navigateOnboardingFlow() throws {
+    fileprivate func navigateOnboardingFlow(repeated skippedIfRepeated: Bool = false) throws {
         try navigateOnboardingFlowWelcome()
         try navigateOnboardingFlowInterestingModules()
         if staticTexts["Consent Example"].waitForExistence(timeout: 5) {
             try navigateOnboardingFlowConsent()
         }
         try navigateOnboardingAccount()
-        try navigateOnboardingFlowHealthKitAccess()
-        try navigateOnboardingFlowNotification()
+        if !skippedIfRepeated {
+            try navigateOnboardingFlowHealthKitAccess()
+            try navigateOnboardingFlowNotification()
+        }
     }
     
     private func navigateOnboardingFlowWelcome() throws {
@@ -82,9 +98,11 @@ extension XCUIApplication {
         
         XCTAssertTrue(staticTexts["First Name"].waitForExistence(timeout: 2))
         try textFields["Enter your first name ..."].enter(value: "Leland")
+        textFields["Enter your first name ..."].typeText("\n")
         
         XCTAssertTrue(staticTexts["Last Name"].waitForExistence(timeout: 2))
         try textFields["Enter your last name ..."].enter(value: "Stanford")
+        textFields["Enter your last name ..."].typeText("\n")
         
         XCTAssertTrue(staticTexts["Leland Stanford"].waitForExistence(timeout: 2))
         staticTexts["Leland Stanford"].firstMatch.swipeUp()
@@ -151,5 +169,12 @@ extension XCUIApplication {
         if alertAllowButton.waitForExistence(timeout: 5) {
            alertAllowButton.tap()
         }
+    }
+    
+    fileprivate func assertOnboardingComplete() throws {
+        let tabBar = tabBars["Tab Bar"]
+        XCTAssertTrue(tabBar.buttons["Schedule"].waitForExistence(timeout: 2))
+        XCTAssertTrue(tabBar.buttons["Contacts"].waitForExistence(timeout: 2))
+        XCTAssertTrue(tabBar.buttons["Mock Upload"].waitForExistence(timeout: 2))
     }
 }


### PR DESCRIPTION
<!--

This source file is part of the Stanford Spezi open-source project

SPDX-FileCopyrightText: 2022 Stanford University and the project authors (see CONTRIBUTORS.md)

SPDX-License-Identifier: MIT

-->

# Skip unnecessary authorization views

## :recycle: Current situation & Problem
The onboarding flow is a crucial aspect of the `SpeziTemplateApplication` as it introduces the user to the application and requests permissions to collect HealthKit data / show Notifications from the user. At the moment, the onboarding flow is very static, guiding the user from one screen to another in a fixed way. 
However, this leads to the fact that the HealthKit authorization view as well as the Notification authorization view are displayed every time the onboarding flow is showcased, even though the permissions requested in both of these steps may already be granted to the application. 
A common manifestation of this problem can be observed by logging out and in again (without deleting the application). The application will erroneously prompt an onboarding step that requests HealthKit and Notification permissions from the user, even if such permissions have previously been granted.

All in all, this behavior leads to **redundant authorization requests**, unnecessarily prolonging the onboarding flow for the application user.

Related to #22.

## :bulb: Proposed solution
The PR aims to reduce the number of redundant authorization requests by utilizing the newly created "authorization granted" flags within the [`SpeziHealthKit`](https://github.com/StanfordSpezi/SpeziHealthKit/pull/7) and [`SpeziScheduler` ](https://github.com/StanfordSpezi/SpeziScheduler/pull/14) packages (see PRs). Based on these flags, the onboarding flow is shorted to potentially skip the health collection authorization requests or the notification authorization request.

The logic of skipping the individual onboarding steps is pretty straightforward. However, thinking future-oriented with large and complex onboarding flows, one could think about providing the application developer with more functionality regarding the onboarding flow from the `SpeziOnboarding` package. An idea would be the representation of the onboarding flow as a state machine with defined states (so screens), transitions between those states, and conditions that need to be fulfilled. One could probably create a nice DSL in Swift (via result builders?) for that functionality. I plan to create a GitHub issue for that in the next few days. Feel free to give some input here!

One has to keep an important fact in mind (elaborated on within the [`SpeziHealthKit` PR](https://github.com/StanfordSpezi/SpeziHealthKit/pull/7): Apple HealthKit doesn't allow developers to check if the user actually gave the authorization to collect certain data points (so the `read` permission, for `share`/ `write` permissions this is in fact possible)). Therefore, the application has to assume that the user gave all required permissions as HealthKit doesn't allow for a differentiation between "access denied" and "no data".  

## :gear: Release Notes 
- Skip unnecessary HealthKit and Notification authorization views if permissions are already granted

## :heavy_plus_sign: Additional Information
At the moment, the TemplateApplication is depending on specific branches of other Spezi packages in order to make the app properly testable locally. Before merging this pull request, the PRs in the dependent packages need to be merged first. Then, one can update the packages to tagged versions within this pull request.

### Related PRs
- [`SpeziHealthKit` PR](https://github.com/StanfordSpezi/SpeziHealthKit/pull/7)
- [`SpeziScheduler` PR](https://github.com/StanfordSpezi/SpeziScheduler/pull/14)
- [`SpeziOnboarding` PR](https://github.com/StanfordSpezi/SpeziOnboarding/pull/9)

### Testing
A UI test is written that checks if the screens are skipped upon a repeated onboarding round (without deleting the application, meaning the authorizations are kept).

This behavior can be easily tested manually by utilizing the `--showOnboarding` flag of the `SpeziTemplateApplication`. It always prompts the user with the onboarding workflow, making it the perfect opportunity to test the potentially skipped views. Another useful flag is also the `--disableFirebase` flag which skips the somewhat lengthy account creation.

### Reviewer Nudging
Code changes aren't too big, don't let yourself distract from the changes in project files.

### Code of Conduct & Contributing Guidelines 

By submitting creating this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md):
- [X] I agree to follow the [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md).
