### PR TITLE
Disable CodeQL job until Swift 5.9 is supported by CodeQL

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -20,16 +20,6 @@ jobs:
   swiftlint:
     name: SwiftLint
     uses: StanfordSpezi/.github/.github/workflows/swiftlint.yml@v2
-  codeql:
-    name: CodeQL
-    uses: StanfordSpezi/.github/.github/workflows/xcodebuild-or-fastlane.yml@v2
-    with:
-      codeql: true
-      xcodeversion: '14.3.1'
-      fastlanelane: codeql
-    permissions:
-      security-events: write
-      actions: read
   buildandtest:
     name: Build and Test
     uses: StanfordSpezi/.github/.github/workflows/xcodebuild-or-fastlane.yml@v2


### PR DESCRIPTION
<!--

This source file is part of the Stanford Spezi open-source project

SPDX-FileCopyrightText: 2022 Stanford University and the project authors (see CONTRIBUTORS.md)

SPDX-License-Identifier: MIT

-->

# *Disable CodeQL job until Swift 5.9 is supported by CodeQL*

## :recycle: Current situation & Problem
At the moment, the [CodeQL analysis engine](https://docs.github.com/en/code-security/code-scanning/automatically-scanning-your-code-for-vulnerabilities-and-errors/about-code-scanning-with-codeql) for [GitHub code scanning](https://docs.github.com/en/code-security/code-scanning/automatically-scanning-your-code-for-vulnerabilities-and-errors/about-code-scanning) doesn't support Swift 5.9: https://github.com/github/roadmap/issues/800
This presents a challenge to our Spezi use case, as we are using Swift 5.9 features.
Issue tracked in: https://github.com/StanfordSpezi/SpeziTemplateApplication/issues/43


## :gear: Release Notes 
- Disable CodeQL job until Swift 5.9 is supported by CodeQL


## :books: Documentation
--


## :white_check_mark: Testing
--


## :pencil: Code of Conduct & Contributing Guidelines 

By submitting creating this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md):
- [X] I agree to follow the [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md).
