### PR TITLE
Fix issues writing to Firestore

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -1,8 +1,9 @@
+rules_version = '2';
 service cloud.firestore {
   match /databases/{database}/documents {
     // Allow only authenticated content owners access
     match /users/{userId}/{documents=**} {
-      allow read, write: if request.auth != null && request.auth.uid == userId
+      allow read, write: if request.auth != null && request.auth.uid == userId;
     }
   }
 }


### PR DESCRIPTION
# Fix firestore rules

## :recycle: Current situation & Problem
The firestore rules were ill-formatted and therefore all write to the firestore simulator were rejected. This PR fixes this problem by updating the `firestore.rules` configuration to include the version information and fixing syntax issues.


## :gear: Release Notes 
* Fixed issues writing to Firestore


## :books: Documentation
--


## :white_check_mark: Testing
--

## :pencil: Code of Conduct & Contributing Guidelines 

By submitting creating this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md).
