### PR TITLE
Support storing arbitrary account details

### DIFF
--- a/TemplateApplication.xcodeproj/project.pbxproj
+++ b/TemplateApplication.xcodeproj/project.pbxproj
@@ -77,6 +77,7 @@
 		97D8B2A42A7653E600715F50 /* ProcessInfo+PreviewSimulator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 97D8B2A32A7653E600715F50 /* ProcessInfo+PreviewSimulator.swift */; };
 		97D8B2AB2A769A6E00715F50 /* OnboardingFlow+PreviewSimulator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 97D8B2AA2A769A6E00715F50 /* OnboardingFlow+PreviewSimulator.swift */; };
 		A9720E432ABB68CC00872D23 /* AccountSetupHeader.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9720E422ABB68CC00872D23 /* AccountSetupHeader.swift */; };
+		A9D83F962B083794000D0C78 /* SpeziFirebaseAccountStorage in Frameworks */ = {isa = PBXBuildFile; productRef = A9D83F952B083794000D0C78 /* SpeziFirebaseAccountStorage */; };
 		A9DFE8A92ABE551400428242 /* AccountButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9DFE8A82ABE551400428242 /* AccountButton.swift */; };
 		A9FE7AD02AA39BAB0077B045 /* AccountSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9FE7ACF2AA39BAB0077B045 /* AccountSheet.swift */; };
 /* End PBXBuildFile section */
@@ -168,6 +169,7 @@
 				2FB099B32A875DF100B20952 /* FirebaseFirestoreSwift in Frameworks */,
 				5661551D2AB8384200209B80 /* SwiftPackageList in Frameworks */,
 				2FB099B12A875DF100B20952 /* FirebaseFirestore in Frameworks */,
+				A9D83F962B083794000D0C78 /* SpeziFirebaseAccountStorage in Frameworks */,
 				2FB099B62A875E2B00B20952 /* HealthKitOnFHIR in Frameworks */,
 				2FE5DC8A29EDD972004B9AB4 /* SpeziLocalStorage in Frameworks */,
 				2FE5DC8C29EDD972004B9AB4 /* SpeziSecureStorage in Frameworks */,
@@ -426,6 +428,7 @@
 				5661551C2AB8384200209B80 /* SwiftPackageList */,
 				9739A0C52AD7B5730084BEA5 /* FirebaseStorage */,
 				97D73D692AD860AD00B47FA0 /* SpeziFirebaseStorage */,
+				A9D83F952B083794000D0C78 /* SpeziFirebaseAccountStorage */,
 			);
 			productName = TemplateApplication;
 			productReference = 653A254D283387FE005D4D48 /* TemplateApplication.app */;
@@ -1199,7 +1202,7 @@
 			repositoryURL = "https://github.com/StanfordSpezi/SpeziAccount.git";
 			requirement = {
 				kind = upToNextMinorVersion;
-				minimumVersion = 0.7.3;
+				minimumVersion = 0.8.0;
 			};
 		};
 		2FE5DC6529EDD894004B9AB4 /* XCRemoteSwiftPackageReference "SpeziContact" */ = {
@@ -1207,7 +1210,7 @@
 			repositoryURL = "https://github.com/StanfordSpezi/SpeziContact.git";
 			requirement = {
 				kind = upToNextMinorVersion;
-				minimumVersion = 0.5.0;
+				minimumVersion = 0.5.1;
 			};
 		};
 		2FE5DC7029EDD8D3004B9AB4 /* XCRemoteSwiftPackageReference "SpeziHealthKit" */ = {
@@ -1222,8 +1225,8 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/StanfordSpezi/SpeziFirebase.git";
 			requirement = {
-				kind = upToNextMinorVersion;
-				minimumVersion = 0.8.0;
+				branch = "fix/use-autoclosure-flexibility";
+				kind = branch;
 			};
 		};
 		2FE5DC8229EDD934004B9AB4 /* XCRemoteSwiftPackageReference "SpeziQuestionnaire" */ = {
@@ -1437,6 +1440,11 @@
 			isa = XCSwiftPackageProductDependency;
 			package = 2FE5DC7329EDD8E6004B9AB4 /* XCRemoteSwiftPackageReference "SpeziFirebase" */;
 			productName = SpeziFirebaseStorage;
+		};
+		A9D83F952B083794000D0C78 /* SpeziFirebaseAccountStorage */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 2FE5DC7329EDD8E6004B9AB4 /* XCRemoteSwiftPackageReference "SpeziFirebase" */;
+			productName = SpeziFirebaseAccountStorage;
 		};
 /* End XCSwiftPackageProductDependency section */
 	};

--- a/TemplateApplication.xcodeproj/project.pbxproj
+++ b/TemplateApplication.xcodeproj/project.pbxproj
@@ -1225,8 +1225,8 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/StanfordSpezi/SpeziFirebase.git";
 			requirement = {
-				branch = "fix/use-autoclosure-flexibility";
-				kind = branch;
+				kind = upToNextMinorVersion;
+				minimumVersion = 0.8.2;
 			};
 		};
 		2FE5DC8229EDD934004B9AB4 /* XCRemoteSwiftPackageReference "SpeziQuestionnaire" */ = {

--- a/TemplateApplication.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/TemplateApplication.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -10,6 +10,15 @@
       }
     },
     {
+      "identity" : "app-check",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/google/app-check.git",
+      "state" : {
+        "revision" : "5746b2d35c91c50581590ed97abe4c06b5037274",
+        "version" : "10.18.0"
+      }
+    },
+    {
       "identity" : "fhirmodels",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/FHIRModels",
@@ -23,8 +32,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/firebase/firebase-ios-sdk.git",
       "state" : {
-        "revision" : "8872dbd7d947acf757abab933da10e83c1842280",
-        "version" : "10.17.0"
+        "revision" : "5de0369ee79ad096c164eb3afeb7921d92a43b58",
+        "version" : "10.18.0"
       }
     },
     {
@@ -77,8 +86,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/StanfordBDHG/HealthKitOnFHIR.git",
       "state" : {
-        "revision" : "fdf8e4543718a940643598e4bd5e750e9c4c5540",
-        "version" : "0.2.4"
+        "revision" : "825e96007d83ed83f81ee49eb3ebab29d7b7ba2f",
+        "version" : "0.2.5"
       }
     },
     {
@@ -149,8 +158,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/StanfordSpezi/SpeziAccount.git",
       "state" : {
-        "revision" : "d65ad46827f748af7f6c99bd783f74225b530747",
-        "version" : "0.7.3"
+        "revision" : "a9d37971e78fbdce02b0f8b57edfd2eecd4bb22e",
+        "version" : "0.8.1"
       }
     },
     {
@@ -158,8 +167,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/StanfordSpezi/SpeziContact.git",
       "state" : {
-        "revision" : "bd38bd769a20ebe89cec75ebc80dcbccfbd25230",
-        "version" : "0.5.0"
+        "revision" : "07515418259c68d6f5058a45b9e70ad0a0706680",
+        "version" : "0.5.1"
       }
     },
     {
@@ -176,8 +185,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/StanfordSpezi/SpeziFirebase.git",
       "state" : {
-        "revision" : "084d697f58dc1a3275677992f6a5884736e3e2f6",
-        "version" : "0.8.0"
+        "branch" : "fix/use-autoclosure-flexibility",
+        "revision" : "108ca3f349c2fbd5fa0193209e17ffa351d1dd82"
       }
     },
     {

--- a/TemplateApplication.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/TemplateApplication.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -185,8 +185,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/StanfordSpezi/SpeziFirebase.git",
       "state" : {
-        "branch" : "fix/use-autoclosure-flexibility",
-        "revision" : "108ca3f349c2fbd5fa0193209e17ffa351d1dd82"
+        "revision" : "db46d60f85aa9d77d247c1f59a30a7b9f7909f82",
+        "version" : "0.8.2"
       }
     },
     {

--- a/TemplateApplication/TemplateAppDelegate.swift
+++ b/TemplateApplication/TemplateAppDelegate.swift
@@ -24,7 +24,11 @@ class TemplateAppDelegate: SpeziAppDelegate {
             if !FeatureFlags.disableFirebase {
                 AccountConfiguration(configuration: [
                     .requires(\.userId),
-                    .collects(\.name)
+                    .requires(\.name),
+
+                    // additional values stored using the `FirestoreAccountStorage` within our Standard implementation
+                    .collects(\.genderIdentity),
+                    .collects(\.dateOfBirth)
                 ])
 
                 if FeatureFlags.useFirebaseEmulator {

--- a/TemplateApplicationUITests/OnboardingTests.swift
+++ b/TemplateApplicationUITests/OnboardingTests.swift
@@ -183,8 +183,9 @@ extension XCUIApplication {
         navigationBars.buttons["Your Account"].tap()
 
         XCTAssertTrue(staticTexts["Account Overview"].waitForExistence(timeout: 5.0))
-        XCTAssertTrue(staticTexts["Leland Stanford"].waitForExistence(timeout: 0.5))
-        XCTAssertTrue(staticTexts[email].waitForExistence(timeout: 0.5))
+        XCTAssertTrue(staticTexts["Leland Stanford"].exists)
+        XCTAssertTrue(staticTexts[email].exists)
+        XCTAssertTrue(staticTexts["Gender Identity, Choose not to answer"].exists)
 
 
         XCTAssertTrue(navigationBars.buttons["Close"].waitForExistence(timeout: 0.5))


### PR DESCRIPTION
# Support storing arbitrary account details

## :recycle: Current situation & Problem
Based on https://github.com/StanfordSpezi/SpeziFirebase/pull/25, this PR adds support for storing arbitrary account values of user accounts. To demonstrate this we add the `genderIdentity` and `birthday` values to demonstrate this feature.


## :gear: Release Notes 
* Support arbitrary account values
* Support collecting the gender identity and birthday of users


## :books: Documentation
--


## :white_check_mark: Testing
Tests were added to verify basic functionality.


## :pencil: Code of Conduct & Contributing Guidelines 

By submitting creating this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md).
