### PR TITLE
Fix Documentation Deployment

### DIFF
--- a/.github/workflows/documentation-deployment.yml
+++ b/.github/workflows/documentation-deployment.yml
@@ -28,7 +28,7 @@ jobs:
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
-    runs-on: macos-13
+    runs-on: [macOS, self-hosted]
     steps:
       - uses: actions/checkout@v4
       - uses: maxim-lobanov/setup-xcode@v1

--- a/.github/workflows/documentation-deployment.yml
+++ b/.github/workflows/documentation-deployment.yml
@@ -28,7 +28,7 @@ jobs:
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
-    runs-on: macos-13
+    runs-on: macos-14
     steps:
       - uses: actions/checkout@v4
       - uses: maxim-lobanov/setup-xcode@v1

--- a/.github/workflows/documentation-deployment.yml
+++ b/.github/workflows/documentation-deployment.yml
@@ -28,7 +28,7 @@ jobs:
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
-    runs-on: [macOS, self-hosted]
+    runs-on: macos-13
     steps:
       - uses: actions/checkout@v4
       - uses: maxim-lobanov/setup-xcode@v1


### PR DESCRIPTION
# Fix Documentation Deployment

## :recycle: Current situation & Problem
- Documentation deployment is failing due to a missing support of GitHub runners for Xcode 15.3.

## :gear: Release Notes 
- Updates the GitHub Action to run on the self-hosted runners.

## :pencil: Code of Conduct & Contributing Guidelines 

By submitting creating this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md).
