### PR TITLE
Fix Main Branch Documentation Deployment Not Working

### DIFF
--- a/.github/workflows/documentation-deployment.yml
+++ b/.github/workflows/documentation-deployment.yml
@@ -29,4 +29,4 @@ jobs:
       id-token: write
     with:
       scheme: 'TemplateApplication'
-      dryrun: ${{ github.ref != 'main' }}
+      dryrun: ${{ github.ref_name != 'main' }}


### PR DESCRIPTION
# Fix Main Branch Documentation Deployment Not Working

## :recycle: Current situation & Problem
- Deployment of the documentation on main was not working as expected. `github.ref` did not evaluate to `main`. Needs to be changed to `ref_name`: https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/accessing-contextual-information-about-workflow-runs


## :gear: Release Notes 
- Fixed documentation deployment on main

## :books: Documentation
- Will be deployed 🚀 

## :pencil: Code of Conduct & Contributing Guidelines 

By submitting creating this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md).
