### PR TITLE
Update dev tool setup script to address Firebase emulator error

### DIFF
--- a/Scripts/setup.sh
+++ b/Scripts/setup.sh
@@ -11,40 +11,42 @@
 #
 # It is required that Xcode is installed on the macOS instance.
 
-# 1. Install homebrew
-export NONINTERACTIVE=1
-/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
-echo; echo 'eval "$(/opt/homebrew/bin/brew shellenv)"' >> ~/.zprofile
-eval "$(/opt/homebrew/bin/brew shellenv)"
+# # 1. Install homebrew
+# export NONINTERACTIVE=1
+# /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
+# echo; echo 'eval "$(/opt/homebrew/bin/brew shellenv)"' >> ~/.zprofile
+# eval "$(/opt/homebrew/bin/brew shellenv)"
 
 
-# 2. Install tools
-brew install java
-sudo ln -sfn /opt/homebrew/opt/openjdk/libexec/openjdk.jdk /Library/Java/JavaVirtualMachines/openjdk.jdk
-echo 'export PATH="/opt/homebrew/opt/openjdk/bin:$PATH"' >> ~/.zshrc
+# # 2. Install tools
+# brew install java
+# sudo ln -sfn /opt/homebrew/opt/openjdk/libexec/openjdk.jdk /Library/Java/JavaVirtualMachines/openjdk.jdk
+# echo 'export PATH="/opt/homebrew/opt/openjdk/bin:$PATH"' >> ~/.zshrc
 
-brew install node
-brew install firebase-cli
-brew install fastlane
-# Set the local correctly to work with fastlane
-echo 'export LC_ALL=en_US.UTF-8' >> ~/.zshrc
-echo 'export LANG=en_US.UTF-8' >> ~/.zshrc
+# brew install node
+# brew install firebase-cli
+# brew install fastlane
+# # Set the local correctly to work with fastlane
+# echo 'export LC_ALL=en_US.UTF-8' >> ~/.zshrc
+# echo 'export LANG=en_US.UTF-8' >> ~/.zshrc
 
-brew install git-lfs
-git lfs install
-git lfs install --system
+# brew install git-lfs
+# git lfs install
+# git lfs install --system
 
-# Ensure that everything on the system is up-to-date
-brew upgrade
+# # Ensure that everything on the system is up-to-date
+# brew upgrade
 
 
 # 3. Test and start the firebase emulator
 
 # Check if firebase.json exists and create if it doesn't
+CREATED_FIREBASE_JSON=false
+
 if [ ! -f "firebase.json" ]; then
   echo "Creating firebase.json file..."
   CREATED_FIREBASE_JSON=true
-  cat > firebase.json << 'EOL'
+  cat << 'EOL' > firebase.json
 {
   "firestore": {
     "rules": "firestore.rules"
@@ -70,6 +72,7 @@ if [ ! -f "firebase.json" ]; then
   }
 }
 EOL
+fi
 
 firebase emulators:exec --project test "echo 'Firebase emulator installed and started successfully!'"
 

--- a/Scripts/setup.sh
+++ b/Scripts/setup.sh
@@ -43,6 +43,7 @@ brew upgrade
 # Check if firebase.json exists and create if it doesn't
 if [ ! -f "firebase.json" ]; then
   echo "Creating firebase.json file..."
+  CREATED_FIREBASE_JSON=true
   cat > firebase.json << 'EOL'
 {
   "firestore": {
@@ -72,5 +73,8 @@ EOL
 
 firebase emulators:exec --project test "echo 'Firebase emulator installed and started successfully!'"
 
-# Clean up the firebase.json file
-rm firebase.json
+# Clean up the firebase.json file only if we created it
+if [ "$CREATED_FIREBASE_JSON" = true ]; then
+  echo "Cleaning up temporary firebase.json file..."
+  rm firebase.json
+fi

--- a/Scripts/setup.sh
+++ b/Scripts/setup.sh
@@ -59,9 +59,6 @@ if [ ! -f "firebase.json" ]; then
       "enabled": true,
       "port": 4000
     },
-    "storage": {
-      "port": 9199
-    },
     "singleProjectMode": true
   }
 }

--- a/Scripts/setup.sh
+++ b/Scripts/setup.sh
@@ -11,31 +11,31 @@
 #
 # It is required that Xcode is installed on the macOS instance.
 
-# # 1. Install homebrew
-# export NONINTERACTIVE=1
-# /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
-# echo; echo 'eval "$(/opt/homebrew/bin/brew shellenv)"' >> ~/.zprofile
-# eval "$(/opt/homebrew/bin/brew shellenv)"
+# 1. Install homebrew
+export NONINTERACTIVE=1
+/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
+echo; echo 'eval "$(/opt/homebrew/bin/brew shellenv)"' >> ~/.zprofile
+eval "$(/opt/homebrew/bin/brew shellenv)"
 
 
-# # 2. Install tools
-# brew install java
-# sudo ln -sfn /opt/homebrew/opt/openjdk/libexec/openjdk.jdk /Library/Java/JavaVirtualMachines/openjdk.jdk
-# echo 'export PATH="/opt/homebrew/opt/openjdk/bin:$PATH"' >> ~/.zshrc
+# 2. Install tools
+brew install java
+sudo ln -sfn /opt/homebrew/opt/openjdk/libexec/openjdk.jdk /Library/Java/JavaVirtualMachines/openjdk.jdk
+echo 'export PATH="/opt/homebrew/opt/openjdk/bin:$PATH"' >> ~/.zshrc
 
-# brew install node
-# brew install firebase-cli
-# brew install fastlane
-# # Set the local correctly to work with fastlane
-# echo 'export LC_ALL=en_US.UTF-8' >> ~/.zshrc
-# echo 'export LANG=en_US.UTF-8' >> ~/.zshrc
+brew install node
+brew install firebase-cli
+brew install fastlane
+# Set the local correctly to work with fastlane
+echo 'export LC_ALL=en_US.UTF-8' >> ~/.zshrc
+echo 'export LANG=en_US.UTF-8' >> ~/.zshrc
 
-# brew install git-lfs
-# git lfs install
-# git lfs install --system
+brew install git-lfs
+git lfs install
+git lfs install --system
 
-# # Ensure that everything on the system is up-to-date
-# brew upgrade
+# Ensure that everything on the system is up-to-date
+brew upgrade
 
 
 # 3. Test and start the firebase emulator
@@ -48,12 +48,6 @@ if [ ! -f "firebase.json" ]; then
   CREATED_FIREBASE_JSON=true
   cat << 'EOL' > firebase.json
 {
-  "firestore": {
-    "rules": "firestore.rules"
-  },
-  "storage": {
-    "rules": "firebasestorage.rules"
-  },
   "emulators": {
     "auth": {
       "port": 9099

--- a/Scripts/setup.sh
+++ b/Scripts/setup.sh
@@ -39,4 +39,38 @@ brew upgrade
 
 
 # 3. Test and start the firebase emulator
+
+# Check if firebase.json exists and create if it doesn't
+if [ ! -f "firebase.json" ]; then
+  echo "Creating firebase.json file..."
+  cat > firebase.json << 'EOL'
+{
+  "firestore": {
+    "rules": "firestore.rules"
+  },
+  "storage": {
+    "rules": "firebasestorage.rules"
+  },
+  "emulators": {
+    "auth": {
+      "port": 9099
+    },
+    "firestore": {
+      "port": 8080
+    },
+    "ui": {
+      "enabled": true,
+      "port": 4000
+    },
+    "storage": {
+      "port": 9199
+    },
+    "singleProjectMode": true
+  }
+}
+EOL
+
 firebase emulators:exec --project test "echo 'Firebase emulator installed and started successfully!'"
+
+# Clean up the firebase.json file
+rm firebase.json


### PR DESCRIPTION
# *Update dev tool setup script to address Firebase emulator error*

## :recycle: Current situation & Problem
If the development tool setup script is run in a directory without a `firebase.json` file (i.e. outside of the Spezi Template Application repository) it throws an error when attempting to test the Firebase emulator suite. As this script installs tools that are independent of the Spezi Template Application itself, it should be able to run completely on its own.

## :gear: Release Notes 
This PR adds a step in the setup script to create a temporary `firebase.json` if one does not exist before testing the firebase emulator suite. The file is removed before the script exits.

## :pencil: Code of Conduct & Contributing Guidelines 

By submitting creating this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md):
- [X] I agree to follow the [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md).
