### PR TITLE
Fix Previews

### DIFF
--- a/TemplateApplication/HomeView.swift
+++ b/TemplateApplication/HomeView.swift
@@ -7,6 +7,7 @@
 //
 
 @_spi(TestingSupport) import SpeziAccount
+import class SpeziScheduler.Scheduler
 import SwiftUI
 
 
@@ -54,6 +55,7 @@ struct HomeView: View {
     
     return HomeView()
         .previewWith(standard: TemplateApplicationStandard()) {
+            Scheduler()
             TemplateApplicationScheduler()
             AccountConfiguration(service: InMemoryAccountService(), activeDetails: details)
         }

--- a/TemplateApplication/Onboarding/NotificationPermissions.swift
+++ b/TemplateApplication/Onboarding/NotificationPermissions.swift
@@ -8,6 +8,7 @@
 
 import SpeziNotifications
 import SpeziOnboarding
+import class SpeziScheduler.Scheduler
 import SwiftUI
 
 
@@ -73,6 +74,7 @@ struct NotificationPermissions: View {
     }
         .previewWith {
             TemplateApplicationScheduler()
+            Scheduler()
         }
 }
 #endif

--- a/TemplateApplication/Onboarding/OnboardingFlow.swift
+++ b/TemplateApplication/Onboarding/OnboardingFlow.swift
@@ -11,6 +11,7 @@ import SpeziFirebaseAccount
 import SpeziHealthKit
 import SpeziNotifications
 import SpeziOnboarding
+import class SpeziScheduler.Scheduler
 import SwiftUI
 
 
@@ -78,7 +79,7 @@ struct OnboardingFlow: View {
             OnboardingDataSource()
             HealthKit()
             AccountConfiguration(service: InMemoryAccountService())
-
+            Scheduler()
             TemplateApplicationScheduler()
         }
 }

--- a/TemplateApplication/Schedule/ScheduleView.swift
+++ b/TemplateApplication/Schedule/ScheduleView.swift
@@ -53,7 +53,7 @@ struct ScheduleView: View {
 
 
 #if DEBUG
-#Preview("ScheduleView") {
+#Preview {
     @Previewable @State var presentingAccount = false
 
     ScheduleView(presentingAccount: $presentingAccount)


### PR DESCRIPTION
# Fix Previews

## :recycle: Current situation & Problem
- Some previews are crashing as the `Scheduler` module is not injected properly. It has removed the conformance to `DefaultInitializable` in the latest major release of Spezi Scheduler.

## :gear: Release Notes 
- Fixes the previews by explicitly spelling out the Scheduler dependency.

## :pencil: Code of Conduct & Contributing Guidelines 

By submitting creating this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md).
