### PR TITLE
default new-file header copyright notices

### DIFF
--- a/TemplateApplication.xcodeproj/xcshareddata/IDETemplateMacros.plist
+++ b/TemplateApplication.xcodeproj/xcshareddata/IDETemplateMacros.plist
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>FILEHEADER</key>
+	<string>
+// This source file is part of the Stanford Spezi Template Application open-source project
+//
+// SPDX-FileCopyrightText: ___YEAR___ Stanford University
+//
+// SPDX-License-Identifier: MIT
+//</string>
+</dict>
+</plist>


### PR DESCRIPTION
# default new-file header copyright notices

## :recycle: Current situation & Problem
This PR adds an `IDETemplateMacros.plist` file, which allows us to control the default header comment Xcode adds to new files created within the SpeziTemplateApplication Xcode project.

## :gear: Release Notes
- configured the Xcode project to use a default new-file header with the Spezi copyright notice

## :books: Documentation
n/a (this will Just Work; nothing needs to be configured)

## :white_check_mark: Testing
n/a

## :pencil: Code of Conduct & Contributing Guidelines
By creating and submitting this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md).
