### PR TITLE
Add targets to Periphery configuration

### DIFF
--- a/.periphery.yml
+++ b/.periphery.yml
@@ -9,3 +9,7 @@
 project: TemplateApplication.xcodeproj
 schemes:
 - TemplateApplication
+targets:
+- TemplateApplication
+- TemplateApplicationTests
+- TemplateApplicationUITests


### PR DESCRIPTION
# Add targets to Periphery configuration

## ♻️ Current situation & Problem

The **Periphery** Static Analysis check fails on every PR with:

```
error: The '--targets' option is required.
```

Periphery 2.21 made `targets` a required option when scanning an Xcode project. The repo's `.periphery.yml` only declared `project` and `schemes`, so the scan aborts during argument parsing before analyzing anything.

## 💡 Proposed solution

Declare the project's targets explicitly in `.periphery.yml`:

```yaml
targets:
- TemplateApplication
- TemplateApplicationTests
- TemplateApplicationUITests
```

This is a tooling regression unrelated to any in-flight feature work — it breaks Static Analysis on all current PRs.

## ⚙️ Release Notes

- Fixed the Periphery Static Analysis check by declaring the scan targets in `.periphery.yml`.

## ✅ Testing

- Verified locally: with `targets:` added, `periphery scan` proceeds past argument parsing and runs the scan; without it, it fails instantly.
- Verified in CI on this PR: the **Periphery** check passes, and the full **Build and Test** job (build + unit + UI tests) is green.

## 📝 Code of Conduct & Contributing Guidelines

By submitting this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md).
