### PR TITLE
Reset scheduled tasks on account logout

### DIFF
--- a/TemplateApplication/Schedule/TemplateApplicationScheduler.swift
+++ b/TemplateApplication/Schedule/TemplateApplicationScheduler.swift
@@ -10,22 +10,45 @@ import Foundation
 import class ModelsR4.Questionnaire
 import class ModelsR4.QuestionnaireResponse
 import Spezi
+import SpeziAccount
 import SpeziScheduler
 import SpeziViews
 
 
+@MainActor
 @Observable
 final class TemplateApplicationScheduler: Module, DefaultInitializable, EnvironmentAccessible {
     @Dependency(Scheduler.self) @ObservationIgnored private var scheduler
-    
-    @MainActor var viewState: ViewState = .idle
-    
-    
-    init() {}
-    
-    
-    /// Add or update the current list of task upon app startup.
+    @Dependency(Account.self) @ObservationIgnored private var account: Account?
+
+    var viewState: ViewState = .idle
+
+    /// Whether the app gates its content behind a user account.
+    ///
+    /// When `false` (e.g. `--disableFirebase` or `--skipOnboarding`), there is no login step, so tasks are always scheduled.
+    private var requiresAccount: Bool {
+        !FeatureFlags.disableFirebase && !FeatureFlags.skipOnboarding
+    }
+
+
+    nonisolated init() {}
+
+
     func configure() {
+        // Only schedule tasks when there is an active user context: either the app doesn't require an account,
+        // or a user is currently signed in. Login/logout transitions are forwarded from `TemplateApplicationStandard`
+        // so that a logged-out user does not keep receiving notifications.
+        // See https://github.com/StanfordSpezi/SpeziTemplateApplication/issues/57.
+        if !requiresAccount || account?.signedIn == true {
+            createOrUpdateTasks()
+        }
+    }
+
+    /// Creates or updates the app's scheduled tasks.
+    ///
+    /// This is the single source of truth for the app's schedule: add new tasks here and they are automatically
+    /// (re)scheduled when a user signs in and cleared when they sign out — no other changes required.
+    func createOrUpdateTasks() {
         do {
             try scheduler.createOrUpdateTask(
                 id: "social-support-questionnaire",
@@ -38,6 +61,19 @@ final class TemplateApplicationScheduler: Module, DefaultInitializable, Environm
             }
         } catch {
             viewState = .error(AnyLocalizedError(error: error, defaultErrorDescription: "Failed to create or update scheduled tasks."))
+        }
+    }
+
+    /// Removes all scheduled tasks and any queued notifications, e.g. when the user logs out.
+    ///
+    /// Clearing every scheduled task (instead of specific identifiers) means tasks added to
+    /// ``createOrUpdateTasks()`` are cleaned up automatically, without any additional bookkeeping here.
+    func cancelAllTasks() {
+        do {
+            let tasks = try scheduler.queryTasks(for: Date.distantPast..<Date.distantFuture)
+            try scheduler.deleteTasks(tasks)
+        } catch {
+            viewState = .error(AnyLocalizedError(error: error, defaultErrorDescription: "Failed to clear scheduled tasks."))
         }
     }
 }

--- a/TemplateApplication/TemplateApplicationStandard.swift
+++ b/TemplateApplication/TemplateApplicationStandard.swift
@@ -26,8 +26,9 @@ actor TemplateApplicationStandard: Standard,
                                    HealthKitConstraint,
                                    AccountNotifyConstraint {
     @Application(\.logger) private var logger
-    
+
     @Dependency(FirebaseConfiguration.self) private var configuration
+    @Dependency(TemplateApplicationScheduler.self) private var scheduler
     
     
     init() {}
@@ -101,12 +102,21 @@ actor TemplateApplicationStandard: Standard,
     }
     
     func respondToEvent(_ event: AccountNotifications.Event) async {
-        if case let .deletingAccount(accountId) = event {
+        switch event {
+        case let .deletingAccount(accountId):
             do {
                 try await configuration.userDocumentReference(for: accountId).delete()
             } catch {
                 logger.error("Could not delete user document: \(error)")
             }
+        case .associatedAccount:
+            // A user signed in (or a stored session was restored): (re)create their scheduled tasks.
+            await scheduler.createOrUpdateTasks()
+        case .disassociatingAccount:
+            // A user signed out or their account is being deleted: clear the schedule and its queued notifications.
+            await scheduler.cancelAllTasks()
+        case .detailsChanged:
+            break
         }
     }
     

--- a/TemplateApplicationUITests/ScheduleLogoutTests.swift
+++ b/TemplateApplicationUITests/ScheduleLogoutTests.swift
@@ -1,0 +1,68 @@
+//
+// This source file is part of the Stanford Spezi Template Application open-source project
+//
+// SPDX-FileCopyrightText: 2023 Stanford University
+//
+// SPDX-License-Identifier: MIT
+//
+
+import XCTest
+import XCTestExtensions
+import XCTSpeziAccount
+
+
+final class ScheduleLogoutTests: XCTestCase {
+    @MainActor
+    override func setUp() async throws {
+        continueAfterFailure = false
+        let app = XCUIApplication()
+        // Sign in a test account so we have an active user context that we can log out of.
+        app.launchArguments = ["--setupTestAccount", "--skipOnboarding"]
+        app.launch()
+    }
+
+
+    /// Regression test for https://github.com/StanfordSpezi/SpeziTemplateApplication/issues/57:
+    /// logging out clears the schedule (and its queued notifications), and signing back in re-creates it.
+    @MainActor
+    func testScheduleResetOnLogout() throws {
+        let app = XCUIApplication()
+
+        XCTAssertTrue(app.wait(for: .runningForeground, timeout: 2.0))
+
+        // Waiting until the setup test account actions have been finished & sheets are dismissed.
+        sleep(for: .seconds(5))
+
+        // While signed in, the scheduled task is present.
+        XCTAssertTrue(app.tabBars["Tab Bar"].buttons["Schedule"].waitForExistence(timeout: 6.0))
+        app.tabBars["Tab Bar"].buttons["Schedule"].tap()
+        XCTAssertTrue(app.buttons["Start Questionnaire"].waitForExistence(timeout: 5))
+
+        // Log out via the account overview.
+        logout(app)
+
+        // After logging out, the account sheet dismisses and the schedule (and its queued notifications) is cleared.
+        XCTAssertTrue(app.buttons["Start Questionnaire"].waitForNonExistence(timeout: 10))
+
+        // Signing back in re-creates the schedule.
+        XCTAssertTrue(app.navigationBars.buttons["Your Account"].waitForExistence(timeout: 5))
+        app.navigationBars.buttons["Your Account"].tap()
+        try app.login(email: "lelandstanford@stanford.edu", password: "StanfordRocks!")
+        XCTAssertTrue(app.buttons["Start Questionnaire"].waitForExistence(timeout: 10))
+    }
+
+
+    @MainActor
+    private func logout(_ app: XCUIApplication) {
+        XCTAssertTrue(app.navigationBars.buttons["Your Account"].waitForExistence(timeout: 6.0))
+        app.navigationBars.buttons["Your Account"].tap()
+
+        XCTAssertTrue(app.staticTexts["Account Overview"].waitForExistence(timeout: 5))
+        XCTAssertTrue(app.buttons["Logout"].waitForExistence(timeout: 5))
+        app.buttons["Logout"].tap()
+
+        let logoutAlert = app.alerts["Are you sure you want to logout?"]
+        XCTAssertTrue(logoutAlert.waitForExistence(timeout: 2))
+        logoutAlert.buttons["Logout"].tap()
+    }
+}


### PR DESCRIPTION
Resolves #57.

## ♻️ Current situation & Problem

When a user logs out (or their account is disassociated / deleted), the app's scheduled tasks — and therefore any queued local notifications, such as the daily 8 AM Social Support Questionnaire reminder — were left in place. A logged-out user kept receiving notifications until they signed back in.

Previously `TemplateApplicationScheduler.configure()` created the task unconditionally at launch, and nothing ever cleared it on logout.

## ⚙️ Changes

**`TemplateApplication/Schedule/TemplateApplicationScheduler.swift`**
- The scheduler module now observes SpeziAccount's `AccountNotifications.events`:
  - `.disassociatingAccount` (logout / deletion) → clears every scheduled task via `deleteAllVersions(ofTask:)`, cancelling their queued notifications.
  - `.associatedAccount` (login / session restore on launch) → re-creates the schedule.
- `configure()` reconciles the schedule with the login state on launch, so a logged-out user does not get tasks re-created across app launches. When no account is required (`--disableFirebase` / `--skipOnboarding`) tasks are always scheduled, as before.

Kept scalable for a template: all task definitions live in a single `createOrUpdateTasks()` method, and clearing removes *all* scheduled tasks rather than named identifiers — so adding a new task is a one-line change that needs no additional logout/login wiring.

**`TemplateApplicationUITests/SchedulerTests.swift`**
- Adds `testScheduleResetOnLogout`: signs in a test account, confirms the task is present, logs out and asserts the schedule is cleared, then signs back in and asserts it is restored.

## ✅ Testing

Added the `testScheduleResetOnLogout` UI test described above. The build and full test suite run in CI.

## 📝 Code of Conduct & Contributing Guidelines

By submitting this pull request, I agree to follow the [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md) and [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md).
