### PR TITLE
Add AI agent onboarding docs (AGENTS.md/CLAUDE.md) and vibe-coder plan

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,89 @@
+<!--
+
+This source file is part of the Stanford Spezi Template Application open-source project
+
+SPDX-FileCopyrightText: 2025 Stanford University and the project authors (see CONTRIBUTORS.md)
+
+SPDX-License-Identifier: MIT
+
+-->
+
+# Working in the Spezi Template Application
+
+Guidance for AI coding agents (Claude Code, Codex, Cursor, Gemini CLI, …) working in this repository.
+
+## What this is
+
+An iOS / iPadOS app template (SwiftUI) built on the [Stanford Spezi](https://github.com/StanfordSpezi/Spezi) ecosystem. It demonstrates the building blocks of a digital‑health app: onboarding, consent, HealthKit collection, scheduled questionnaires, contacts, notifications, and account + data sync (Firebase, optional). Use it as the starting point for a Spezi‑based Apple app.
+
+## Coming from SpeziVibe?
+
+If `docs/planning/` and/or `docs/implementation-plan.md` exist in this repo, they were produced by the [SpeziVibe](https://github.com/StanfordSpezi/SpeziVibe) planning skills and dropped here for you. **Read them first**, then build through `docs/implementation-plan.md` one milestone at a time, checking in after each. If those files are absent, this is a fresh clone — start from **Where to add things** below.
+
+## Architecture — Spezi in a nutshell
+
+- **Entry point:** `TemplateApplication/TemplateApplication.swift` (`@main`).
+- **Configuration:** `TemplateApplication/TemplateApplicationDelegate.swift` — a `SpeziAppDelegate` whose `configuration` wires up **one `Standard`** plus a list of **`Module`s** (Account, HealthKit, Scheduler, Notifications, Firebase, …).
+- **The `Standard`:** `TemplateApplication/TemplateApplicationStandard.swift` — the app‑wide data hub. It receives HealthKit samples, questionnaire responses, consent, and account events, and either stores them (Firestore) or logs them (no‑backend mode).
+- **Feature folders** under `TemplateApplication/`: `Onboarding/`, `Schedule/`, `Account/`, `Contacts/`, `Firestore/`, `SharedContext/`.
+- **Feature flags:** `TemplateApplication/SharedContext/FeatureFlags.swift`.
+
+## Run it
+
+Simplest path: open `TemplateApplication.xcodeproj` in Xcode, select the `TemplateApplication` scheme and an iPhone simulator, and Run (⌘R). **The scheme passes `--disableFirebase` by default, so the app runs with no backend** — no Firebase account or emulator required.
+
+To exercise the full backend (login + data upload), start the Firebase emulator and turn the flag off:
+
+```bash
+cd firebase && firebase emulators:start   # requires Scripts/setup.sh first (installs the Firebase CLI)
+```
+
+then edit the scheme's Run arguments to disable `--disableFirebase`.
+
+## Build & test from the CLI
+
+Build for a simulator (substitute any installed iPhone simulator for the name):
+
+```bash
+xcodebuild build -project TemplateApplication.xcodeproj -scheme TemplateApplication \
+  -destination 'platform=iOS Simulator,name=iPhone 16 Pro' \
+  -skipPackagePluginValidation -skipMacroValidation
+```
+
+- `-skipPackagePluginValidation -skipMacroValidation` are **required** on the CLI, or the SwiftLint / macro build‑tool plugins fail validation before compilation.
+- Run the test suite with `fastlane test` (matches CI), or a subset with `xcodebuild test … -only-testing:TemplateApplicationUITests/<Class>`.
+- **Account / sign‑in UI tests need two things:** the Firebase emulator running, **and an ad‑hoc‑signed build**. Building with `CODE_SIGNING_ALLOWED=NO` strips the keychain entitlement and sign‑in silently fails (`SecItemAdd -34018`). Use ad‑hoc signing instead: append `CODE_SIGN_IDENTITY="-" CODE_SIGNING_REQUIRED=NO` (no real signing identity needed for the simulator).
+
+## Conventions
+
+- **SwiftLint is strict and enforced in CI** (`.swiftlint.yml`). No force‑unwrap / force‑try, keep within the configured line length, etc. Lint before you finish.
+- **Every new source file needs a license header** (REUSE compliance is checked in CI). Copy the license/copyright header block verbatim from any existing file of the same type.
+- Swift 6 strict concurrency is on — respect actor isolation and `Sendable`.
+- **Gotcha:** inside the `Schedule/` files, `Task` refers to `SpeziScheduler.Task`, *not* Swift concurrency. Use `_Concurrency.Task` when you need an async task there.
+
+## Where to add things
+
+| Goal | Where |
+| --- | --- |
+| A new tab / screen | `HomeView.swift` (the `TabView`) |
+| A scheduled task / reminder | `Schedule/TemplateApplicationScheduler.swift` → `configure()` |
+| A questionnaire | add the FHIR questionnaire JSON to the app bundle, reference it via `Bundle.main.questionnaire(withName:)` from the scheduler |
+| Collect a HealthKit sample type | `TemplateApplicationDelegate.swift` → the `healthKit` configuration |
+| Store / handle collected data | `TemplateApplicationStandard.swift` (`handleNewSamples`, `add(response:)`, `store(consent:)`, …) |
+| An onboarding step | `Onboarding/` + `Onboarding/OnboardingFlow.swift` |
+| Contact info | `Contacts/Contacts.swift` |
+| A launch feature flag | `SharedContext/FeatureFlags.swift` |
+
+## Plan with SpeziVibe
+
+For product, clinical, regulatory, and data‑model planning (needs‑finding, UX, FHIR data model, compliance, study design), install the [SpeziVibe](https://github.com/StanfordSpezi/SpeziVibe) skills into your agent:
+
+```bash
+npx skills add StanfordSpezi/SpeziVibe --all
+```
+
+They produce planning briefs and a `docs/implementation-plan.md` that you then build here (see **Coming from SpeziVibe?** above).
+
+## More documentation
+
+Human‑oriented DocC articles live in `TemplateApplication/Supporting Files/TemplateApplication.docc/`: **Setup** (build & run), **Modify** (extend onboarding / schedule / questionnaires), and **Create** (fork & rename for your own project).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,15 @@
+<!--
+
+This source file is part of the Stanford Spezi Template Application open-source project
+
+SPDX-FileCopyrightText: 2025 Stanford University and the project authors (see CONTRIBUTORS.md)
+
+SPDX-License-Identifier: MIT
+
+-->
+
+# CLAUDE.md
+
+Guidance for AI coding agents working in this repository lives in [`AGENTS.md`](AGENTS.md), imported below so it loads automatically in Claude Code.
+
+@AGENTS.md

--- a/README.md
+++ b/README.md
@@ -18,6 +18,19 @@ This repository contains the Spezi Template Application.
 It demonstrates using the [Spezi](https://github.com/StanfordSpezi/Spezi) ecosystem and builds on top of the [Stanford Biodesign Digital Health Template Application](https://github.com/StanfordBDHG/TemplateApplication).
 
 
+## Quick Start
+
+Want to try it in a couple of minutes, with no backend to set up?
+
+1. Clone the repository and open `TemplateApplication.xcodeproj` in Xcode.
+2. Select the `TemplateApplication` scheme and an iPhone simulator.
+3. Run (⌘R). The scheme runs with `--disableFirebase` by default, so **no Firebase account or emulator is required**.
+
+To use the full backend (login and data upload), follow the [Setup guide](<TemplateApplication/Supporting Files/TemplateApplication.docc/Setup.md>) to start the Firebase Emulator Suite.
+
+**Building with an AI coding agent?** This repo ships an [`AGENTS.md`](AGENTS.md) (and [`CLAUDE.md`](CLAUDE.md)) that orient Claude Code, Codex, Cursor, and other agents to how the project is structured, run, and tested. For product and clinical planning, install the [SpeziVibe](https://github.com/StanfordSpezi/SpeziVibe) skills into your agent with `npx skills add StanfordSpezi/SpeziVibe --all` — their planning briefs and implementation plan drop straight into this template for you to build.
+
+
 ## Application Content
 
 The following screenshots show a wide variety of features based on Spezi Modules that are part of the Spezi Template Application.

--- a/docs/vibe-plan.md
+++ b/docs/vibe-plan.md
@@ -1,0 +1,79 @@
+<!--
+
+This source file is part of the Stanford Spezi Template Application open-source project
+
+SPDX-FileCopyrightText: 2025 Stanford University and the project authors (see CONTRIBUTORS.md)
+
+SPDX-License-Identifier: MIT
+
+-->
+
+# Making the Spezi Template Application vibe‑coder friendly
+
+A plan to make this template a first‑class target for developers building with AI coding agents, and a clean landing zone for the [SpeziVibe](https://github.com/StanfordSpezi/SpeziVibe) planning funnel.
+
+## Why this matters
+
+"Vibe coders" build with an AI partner (Claude Code, Codex, Cursor, Gemini CLI). Their success depends on the repo giving the agent a clear mental model, frictionless run/test loops, and known extension points. Today this template has excellent human docs (DocC Setup / Modify / Create) and runs with no backend by default, but it ships **no machine‑facing guidance** for agents. Closing that gap benefits every downstream project that clones this template.
+
+## The key insight: this template is SpeziVibe's landing zone
+
+SpeziVibe is a planning funnel made of installable skills:
+
+```
+idea → build-an-app (orchestrator)
+     → planning skills (biodesign-needs-finding, digital-health-ux-planning,
+       health-data-model-planning, fhir-data-model-design,
+       digital-health-compliance-planning, digital-health-study-planning)
+     → app-build-planner  → writes docs/implementation-plan.md
+     → spezi-platform-selection → clone-template.sh apple-native
+          → git clone StanfordSpezi/SpeziTemplateApplication   ← THIS REPO
+          → moves docs/planning/ + docs/implementation-plan.md into the clone
+     → coding agent builds here, milestone by milestone
+```
+
+`spezi-platform-selection/scripts/clone-template.sh` clones **this repo** for the `apple-native` path. SpeziVibe owns *planning*; the handoff to *implementation* happens **inside this template**. So making the template vibe‑coder friendly means making it (a) a great standalone starting point and (b) a great receiver of the SpeziVibe handoff.
+
+## Workstreams
+
+### WS1 — Agent onboarding, SpeziVibe‑aware  ·  _in progress_
+
+`AGENTS.md` (+ a thin `CLAUDE.md` that imports it) and a README **Quick Start**. Covers the mental model, run/test/build commands, the non‑obvious gotchas (emulator + ad‑hoc signing for auth tests, `-skipPackagePluginValidation`, `Task` = `SpeziScheduler.Task`), SwiftLint/REUSE conventions, and a "where to add X" file map. Includes a **"Coming from SpeziVibe?"** section telling the agent to read `docs/planning/` + `docs/implementation-plan.md` first and build milestone‑by‑milestone. Highest leverage; everything else references it.
+
+### WS2 — Adopt SpeziVibe's `docs/` convention  ·  _planned_
+
+Add `docs/planning/` (with a `.gitkeep`) and a short `docs/README.md` documenting the convention: planning briefs and `implementation-plan.md` land here. Makes the handoff location canonical so `AGENTS.md` and skills can rely on it.
+
+### WS3 — Bundle template‑specific implementation skills  ·  _planned_
+
+SpeziVibe ships planning + platform‑selection skills but **no skills for building inside this codebase**. Ship the "last mile" as `.claude/skills/<name>/SKILL.md` (same format SpeziVibe uses), present the instant the repo is cloned — no `npx` step. Start with the highest‑use trio and expand:
+
+| Skill | Does |
+| --- | --- |
+| `run` | Launch in the simulator with the right flags (no‑backend default; emulator path) |
+| `verify` | Build + SwiftLint + a fast test, using the exact incantations that work here |
+| `add-questionnaire` | Add a FHIR questionnaire JSON and wire it into the scheduler |
+| `add-scheduled-task` | Add a task to `TemplateApplicationScheduler.configure()` |
+| `add-healthkit-type` | Register a new sample type + its storage |
+| `add-tab` / `add-onboarding-step` | Add a screen or onboarding step following existing patterns |
+
+These complement SpeziVibe cleanly: SpeziVibe decides *what* to build; these know *how* to build it here.
+
+### WS4 — Cross‑link the two directions  ·  _planned_
+
+From the template (README + `AGENTS.md`): recommend installing SpeziVibe for planning. From SpeziVibe (its `spezi-platform-selection` setup guide): note that the template now ships `AGENTS.md` + implementation skills so the agent reads them post‑clone.
+
+### WS5 — Distribution  ·  _optional / later_
+
+Decide whether the implementation skills live only in the template (present on clone — recommended for zero friction) or are also published for `npx skills add` (e.g., contributed to SpeziVibe or a companion `spezivibe-ios-skills`). Bundling‑in‑template wins for the funnel; publishing wins for people extending an existing app.
+
+## Sequencing
+
+1. **WS1** — agent onboarding files (unblocks everything).
+2. **WS2** — `docs/` convention (small; makes the handoff canonical).
+3. **WS3** — implementation skills, starting with `run` + `verify` + `add-questionnaire`.
+4. **WS4 / WS5** — cross‑linking and distribution once the above land.
+
+## Related
+
+- Issue [#28](https://github.com/StanfordSpezi/SpeziTemplateApplication/issues/28) (mock mode) overlaps with WS3/WS5: a mock account service on the `--disableFirebase` path would let vibe coders exercise account features with no backend at all.


### PR DESCRIPTION
## ♻️ Current situation & Problem

The template has strong human-facing docs (DocC Setup / Modify / Create) and runs with no backend by default, but it ships **no machine-facing guidance for AI coding agents**. It's also the clone target of the [SpeziVibe](https://github.com/StanfordSpezi/SpeziVibe) planning funnel (`spezi-platform-selection` clones this repo for the `apple-native` path), yet there's nothing here to receive that handoff.

## ⚙️ Changes (WS1 — agent onboarding)

- **`AGENTS.md`** — orients any coding agent (Claude Code, Codex, Cursor, Gemini CLI): the Spezi mental model, how to run (no-backend default) / build / test, the non-obvious gotchas (Firebase emulator + ad-hoc signing for auth tests, `-skipPackagePluginValidation`, `Task` = `SpeziScheduler.Task`), SwiftLint/REUSE conventions, and a "where to add X" file map. Includes a **"Coming from SpeziVibe?"** section that tells the agent to read `docs/planning/` + `docs/implementation-plan.md` first and build milestone-by-milestone.
- **`CLAUDE.md`** — thin file that imports `AGENTS.md` (single source of truth) so it loads automatically in Claude Code.
- **README Quick Start** — clone → run in a couple of minutes with no backend, plus pointers to the agent docs and SpeziVibe.
- **`docs/vibe-plan.md`** — a living plan for the broader effort (WS1–WS5), framing this template as SpeziVibe's implementation landing zone.

Docs-only; no source changes. This is WS1 of the plan in `docs/vibe-plan.md`; WS2 (adopt the `docs/` handoff convention) and WS3 (bundle template-specific implementation skills) are proposed as follow-ups.

## ✅ Testing

Docs only. REUSE compliance verified locally (`reuse lint` → compliant); links point at existing files.

## 📝 Code of Conduct & Contributing Guidelines

By submitting this pull request, I agree to follow the [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md) and [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md).
